### PR TITLE
fix(tools): cancel in-flight bash and web-fetch on user stop

### DIFF
--- a/src/main/agent/sandbox/local.test.ts
+++ b/src/main/agent/sandbox/local.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from 'bun:test';
+import { tmpdir } from 'node:os';
+import { LocalSandbox } from './local';
+
+test('exec returns command output', async () => {
+  const sb = new LocalSandbox(tmpdir());
+  const { output, exitCode } = await sb.exec('echo hello');
+  expect(output.trim()).toBe('hello');
+  expect(exitCode).toBe(0);
+});
+
+test('exec aborts a long-running command instead of waiting it out', async () => {
+  const sb = new LocalSandbox(tmpdir());
+  const ac = new AbortController();
+  const started = Date.now();
+  setTimeout(() => ac.abort(), 50);
+  const { output } = await sb.exec('sleep 30', { signal: ac.signal });
+  // Resolves promptly because the child is killed, not after sleep 30 finishes.
+  expect(Date.now() - started).toBeLessThan(5_000);
+  expect(output).toContain('[aborted]');
+});
+
+test('exec returns immediately when the signal is already aborted', async () => {
+  const sb = new LocalSandbox(tmpdir());
+  const { output, exitCode } = await sb.exec('echo nope', { signal: AbortSignal.abort() });
+  expect(output).toBe('[aborted]');
+  expect(exitCode).toBe(1);
+});

--- a/src/main/agent/sandbox/local.ts
+++ b/src/main/agent/sandbox/local.ts
@@ -55,13 +55,29 @@ export class LocalSandbox implements Sandbox {
     return out;
   }
 
-  exec(command: string): Promise<{ output: string; exitCode: number }> {
+  /**
+   * `signal` wires this command to the run's cancellation: when the user stops
+   * the turn, Node's spawn option kills the child with SIGTERM (emitting an
+   * AbortError on 'error') instead of leaving it running detached. Without it a
+   * stopped turn would orphan whatever was mid-flight. A user-driven abort is an
+   * expected stop, not a failure, so it settles gracefully rather than throwing.
+   */
+  exec(
+    command: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<{ output: string; exitCode: number }> {
     return new Promise((resolvePromise, reject) => {
+      const signal = opts?.signal;
+      if (signal?.aborted) {
+        resolvePromise({ output: '[aborted]', exitCode: 1 });
+        return;
+      }
       const shell = process.env.SHELL || '/bin/zsh';
       // A pipe (not a PTY): stdout isn't a tty, so CLIs auto-drop color and
       // progress animations, leaving clean text for the model.
-      const child = spawn(shell, ['-lc', command], { cwd: this.root, env: process.env });
+      const child = spawn(shell, ['-lc', command], { cwd: this.root, env: process.env, signal });
       let out = '';
+      let settled = false;
       const collect = (d: Buffer): void => {
         out += d.toString('utf8');
       };
@@ -72,11 +88,23 @@ export class LocalSandbox implements Sandbox {
         child.kill();
       }, EXEC_TIMEOUT_MS);
       child.on('error', (err) => {
+        if (settled) return;
+        settled = true;
         clearTimeout(timer);
+        if (signal?.aborted) {
+          resolvePromise({ output: `${out}\n[aborted]`.trim(), exitCode: 1 });
+          return;
+        }
         reject(err);
       });
       child.on('close', (code) => {
+        if (settled) return;
+        settled = true;
         clearTimeout(timer);
+        if (signal?.aborted) {
+          resolvePromise({ output: `${out}\n[aborted]`.trim(), exitCode: code ?? 1 });
+          return;
+        }
         resolvePromise({ output: out, exitCode: code ?? 0 });
       });
     });

--- a/src/main/agent/sandbox/types.ts
+++ b/src/main/agent/sandbox/types.ts
@@ -12,5 +12,8 @@ export interface Sandbox {
   readFile(path: string): Promise<string>;
   writeFile(path: string, content: string, append?: boolean): Promise<{ bytes: number }>;
   list(path: string, maxDepth?: number): Promise<string[]>;
-  exec(command: string): Promise<{ output: string; exitCode: number }>;
+  exec(
+    command: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<{ output: string; exitCode: number }>;
 }

--- a/src/main/agent/tools/builtins/bash.test.ts
+++ b/src/main/agent/tools/builtins/bash.test.ts
@@ -55,6 +55,22 @@ test('surfaces exec errors as an Error string', async () => {
   );
 });
 
+test('forwards the abort signal to sandbox.exec', async () => {
+  const ac = new AbortController();
+  let received: AbortSignal | undefined;
+  const t = bashTool(
+    ctx({
+      exec: async (_command, o) => {
+        received = o?.signal;
+        return { output: 'ok', exitCode: 0 };
+      },
+    }),
+  );
+  // biome-ignore lint/suspicious/noExplicitAny: only abortSignal matters here
+  await t.execute?.({ description: 'x', command: 'echo' }, { abortSignal: ac.signal } as any);
+  expect(received).toBe(ac.signal);
+});
+
 const noopProc: ShellProc = { onData() {}, onExit() {}, kill() {} };
 
 test('run_in_background starts a shell via the registry and returns its id', async () => {

--- a/src/main/agent/tools/builtins/bash.ts
+++ b/src/main/agent/tools/builtins/bash.ts
@@ -21,14 +21,14 @@ export const bashTool = (ctx: ToolCtx) =>
           'Run as a long-running background shell. Returns a shell id immediately; read its output with bash_output and stop it with kill_shell.',
         ),
     }),
-    execute: async ({ command, run_in_background }) => {
+    execute: async ({ command, run_in_background }, { abortSignal }) => {
       if (run_in_background) {
         if (!ctx.bgShells) return 'Error: background shells are unavailable.';
         const shellId = ctx.bgShells.start(command, ctx.workspaceRoot);
         return `Started background shell ${shellId}. Read its output with bash_output and stop it with kill_shell.`;
       }
       try {
-        const { output, exitCode } = await ctx.sandbox.exec(command);
+        const { output, exitCode } = await ctx.sandbox.exec(command, { signal: abortSignal });
         const text = output.trimEnd();
         const body = text === '' ? '(no output)' : middleTruncate(text, BASH_MAX);
         return exitCode === 0 ? body : `${body}\nExit Code: ${exitCode}`;

--- a/src/main/agent/tools/builtins/web-fetch.ts
+++ b/src/main/agent/tools/builtins/web-fetch.ts
@@ -32,9 +32,9 @@ export const webFetchTool = () =>
         .describe('Why you are fetching this page, in short words. ALWAYS PROVIDE THIS FIRST.'),
       url: z.url().describe('The absolute http(s) URL to fetch.'),
     }),
-    execute: async ({ url }) => {
+    execute: async ({ url }, { abortSignal }) => {
       try {
-        return await fetchAsMarkdown(url);
+        return await fetchAsMarkdown(url, abortSignal);
       } catch (err) {
         if (err instanceof Error && err.name === 'TimeoutError') {
           return `Error: timed out fetching ${url} after ${FETCH_TIMEOUT_MS / 1000}s`;
@@ -44,16 +44,20 @@ export const webFetchTool = () =>
     },
   });
 
-async function fetchAsMarkdown(url: string): Promise<string> {
+async function fetchAsMarkdown(url: string, abortSignal?: AbortSignal): Promise<string> {
   const parsed = new URL(url);
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     return `Error: only http(s) URLs are supported, got ${parsed.protocol}`;
   }
 
+  // Abort on either the fetch timeout or the user stopping the turn; whichever
+  // fires first propagates its reason, so a timeout still surfaces as TimeoutError.
+  const timeout = AbortSignal.timeout(FETCH_TIMEOUT_MS);
+  const signal = abortSignal ? AbortSignal.any([abortSignal, timeout]) : timeout;
   const res = await fetch(url, {
     headers: { 'User-Agent': USER_AGENT, Accept: 'text/html,application/xhtml+xml,*/*' },
     redirect: 'follow',
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    signal,
   });
   if (!res.ok) return `Error: HTTP ${res.status} ${res.statusText} for ${url}`;
 


### PR DESCRIPTION
## 问题

用户点 Stop 时,abortSignal 走通了 agent loop 和 model stream(`runAgent` → 主 `streamText` → AI SDK 转发给工具 execute → `task` 工具 → `runSubagent` → 子 agent `streamText`),但**断在了叶子工具**:

- `bash` 前台命令直接 `ctx.sandbox.exec(command)`,没接 signal;`LocalSandbox.exec` 里 `spawn` 出的子进程只在自己的 `EXEC_TIMEOUT_MS` 到点才被 kill。→ 停一轮后,命令继续跑成 orphaned 进程,白烧资源、占着 workspace。
- `web-fetch` 只用了自己的 `AbortSignal.timeout`,忽略了 run 的 signal。
- 子 agent 继承同样的链路,所以被取消的 task 也会留下跑着的活。

## 改动

把工具 execute 的 `abortSignal` 一路接通:

- `bash` 透传给 `sandbox.exec(command, { signal })`。
- `LocalSandbox.exec` 把 signal 交给 `spawn(..., { signal })`,abort 时 Node 用 SIGTERM 杀子进程;user-driven abort 视为正常停止,优雅 settle(标记 `[aborted]`)而非抛错。
- `web-fetch` 用 `AbortSignal.any([abortSignal, timeout])` 合并用户取消与超时(timeout 仍以 TimeoutError 冒出,原有提示不变)。

`Sandbox.exec` 接口加可选 `opts?: { signal?: AbortSignal }`。

## 测试

- `local.test.ts`(新增):`sleep 30` + 50ms 后 abort,断言 5s 内返回且输出含 `[aborted]`;已 aborted 的 signal 立即返回;基础 `echo` 回归。
- `bash.test.ts`:新增「abortSignal 透传到 `sandbox.exec`」用例。
- 全量:lint clean、typecheck clean、303/303 pass。

## 已知边角(本 PR 不处理)

`spawn(shell, ['-lc', cmd])` 的 `child.kill()` 只 SIGTERM 那个 shell,管道/后台 fork 出的孙子进程可能残留 —— 现有 timeout 路径也有同样问题,不是本次引入。要彻底干净需 `detached: true` + 杀进程组,建议单独 backlog。

🤖 Generated with [Claude Code](https://claude.com/claude-code)