### PR TITLE
fix(tools): kill the whole process tree, not just the shell

### DIFF
--- a/src/main/agent/sandbox/background-shells.ts
+++ b/src/main/agent/sandbox/background-shells.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { killProcessTree } from './kill-tree';
 
 /**
  * Registry of long-running shell processes that outlive a single tool call —
@@ -40,8 +41,14 @@ type Session = {
 const defaultSpawn: SpawnShell = (command, cwd) => {
   // A pipe (not a PTY): dev servers and watchers detect the non-tty stdout and
   // emit plain text instead of color + spinner redraws, which keeps the buffer
-  // readable for the model.
-  const child = spawn(process.env.SHELL || '/bin/zsh', ['-lc', command], { cwd, env: process.env });
+  // readable for the model. `detached` puts the shell in its own process group
+  // so kill() can reap the dev server / watcher it forked, not just the shell —
+  // otherwise kill_shell and app-quit cleanup would leave those orphaned.
+  const child = spawn(process.env.SHELL || '/bin/zsh', ['-lc', command], {
+    cwd,
+    env: process.env,
+    detached: true,
+  });
   return {
     onData(cb) {
       child.stdout?.on('data', (d: Buffer) => cb(d.toString('utf8')));
@@ -51,7 +58,7 @@ const defaultSpawn: SpawnShell = (command, cwd) => {
       child.on('close', (code) => cb({ exitCode: code ?? 0 }));
     },
     kill() {
-      child.kill();
+      killProcessTree(child);
     },
   };
 };

--- a/src/main/agent/sandbox/kill-tree.test.ts
+++ b/src/main/agent/sandbox/kill-tree.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from 'bun:test';
+import { spawn } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { killProcessTree } from './kill-tree';
+
+const SHELL = process.env.SHELL || '/bin/zsh';
+
+function alive(pid: number): boolean {
+  try {
+    return process.kill(pid, 0);
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(
+  pred: () => boolean | Promise<boolean>,
+  timeoutMs = 5_000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await pred()) return true;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return false;
+}
+
+test('kills a forked grandchild, not just the shell', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'atrium-kill-'));
+  const pidFile = join(dir, 'gc.pid');
+  // The shell forks a grandchild (the `&`), which records its own pid and lingers.
+  // A plain child.kill() would reap only the shell and leave this pid running.
+  const child = spawn(SHELL, ['-lc', `sh -c 'echo $$ > ${pidFile}; sleep 30' & sleep 30`], {
+    detached: true,
+  });
+
+  const gotPid = await waitFor(async () => {
+    try {
+      return (await readFile(pidFile, 'utf8')).trim().length > 0;
+    } catch {
+      return false;
+    }
+  });
+  expect(gotPid).toBe(true);
+  const gcPid = Number((await readFile(pidFile, 'utf8')).trim());
+  expect(gcPid).toBeGreaterThan(0);
+  expect(alive(gcPid)).toBe(true);
+
+  killProcessTree(child);
+
+  expect(await waitFor(() => !alive(gcPid))).toBe(true);
+  await rm(dir, { recursive: true, force: true });
+}, 15_000);
+
+test('escalates to SIGKILL when the process ignores SIGTERM', async () => {
+  // trap '' TERM makes the shell ignore SIGTERM; only SIGKILL can end it.
+  const child = spawn(SHELL, ['-lc', "trap '' TERM; sleep 30"], { detached: true });
+  const pid = child.pid;
+  expect(pid).toBeDefined();
+  await waitFor(() => alive(pid as number), 1_000);
+
+  killProcessTree(child, 200);
+
+  expect(await waitFor(() => !alive(pid as number))).toBe(true);
+}, 15_000);

--- a/src/main/agent/sandbox/kill-tree.ts
+++ b/src/main/agent/sandbox/kill-tree.ts
@@ -1,0 +1,36 @@
+import type { ChildProcess } from 'node:child_process';
+
+const KILL_GRACE_MS = 4_000;
+
+/**
+ * Terminate a detached child process AND every process it spawned.
+ *
+ * A child started with `detached: true` becomes its own process-group leader
+ * (the group id equals its pid), so signaling the *negative* pid reaches the
+ * whole group: the shell plus the dev server / watcher / compiler it forked. A
+ * plain `child.kill()` signals only the shell, leaving those grandchildren
+ * orphaned — holding ports, burning CPU, surviving app quit.
+ *
+ * SIGTERM first for a clean shutdown; if the group is still alive after a grace
+ * period (something trapped or ignored SIGTERM), escalate to SIGKILL. The grace
+ * timer is unref'd so it never keeps the app alive on its own, and the liveness
+ * recheck avoids racing a SIGKILL against a pid the OS has already recycled.
+ */
+export function killProcessTree(child: ChildProcess, graceMs = KILL_GRACE_MS): void {
+  const pid = child.pid;
+  if (pid === undefined) return;
+  if (!signalGroup(pid, 'SIGTERM')) return;
+  const timer = setTimeout(() => {
+    if (signalGroup(pid, 0)) signalGroup(pid, 'SIGKILL');
+  }, graceMs);
+  timer.unref?.();
+}
+
+/** Signal a whole process group by negative pid. Signal 0 just tests liveness. Returns false if the group is already gone. */
+function signalGroup(pid: number, signal: NodeJS.Signals | 0): boolean {
+  try {
+    return process.kill(-pid, signal);
+  } catch {
+    return false;
+  }
+}

--- a/src/main/agent/sandbox/local.ts
+++ b/src/main/agent/sandbox/local.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { shouldIgnore } from './ignore';
+import { killProcessTree } from './kill-tree';
 import { resolveInWorkspace } from './paths';
 import type { Sandbox } from './types';
 
@@ -56,11 +57,11 @@ export class LocalSandbox implements Sandbox {
   }
 
   /**
-   * `signal` wires this command to the run's cancellation: when the user stops
-   * the turn, Node's spawn option kills the child with SIGTERM (emitting an
-   * AbortError on 'error') instead of leaving it running detached. Without it a
-   * stopped turn would orphan whatever was mid-flight. A user-driven abort is an
-   * expected stop, not a failure, so it settles gracefully rather than throwing.
+   * `signal` wires this command to the run's cancellation: stopping the turn (or
+   * hitting the timeout) kills the whole process tree, not just the shell, so a
+   * dev server / compiler the command forked can't outlive the turn as an
+   * orphan. A user-driven abort is an expected stop, not a failure, so it settles
+   * gracefully rather than throwing.
    */
   exec(
     command: string,
@@ -74,8 +75,14 @@ export class LocalSandbox implements Sandbox {
       }
       const shell = process.env.SHELL || '/bin/zsh';
       // A pipe (not a PTY): stdout isn't a tty, so CLIs auto-drop color and
-      // progress animations, leaving clean text for the model.
-      const child = spawn(shell, ['-lc', command], { cwd: this.root, env: process.env, signal });
+      // progress animations, leaving clean text for the model. `detached` puts
+      // the shell in its own process group so killProcessTree can reap whatever
+      // it spawned.
+      const child = spawn(shell, ['-lc', command], {
+        cwd: this.root,
+        env: process.env,
+        detached: true,
+      });
       let out = '';
       let settled = false;
       const collect = (d: Buffer): void => {
@@ -83,30 +90,26 @@ export class LocalSandbox implements Sandbox {
       };
       child.stdout?.on('data', collect);
       child.stderr?.on('data', collect);
+      const onAbort = (): void => {
+        out += '\n[aborted]';
+        killProcessTree(child);
+      };
+      signal?.addEventListener('abort', onAbort, { once: true });
       const timer = setTimeout(() => {
         out += '\n[timed out]';
-        child.kill();
+        killProcessTree(child);
       }, EXEC_TIMEOUT_MS);
-      child.on('error', (err) => {
+      const finish = (settle: () => void): void => {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
-        if (signal?.aborted) {
-          resolvePromise({ output: `${out}\n[aborted]`.trim(), exitCode: 1 });
-          return;
-        }
-        reject(err);
-      });
-      child.on('close', (code) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        if (signal?.aborted) {
-          resolvePromise({ output: `${out}\n[aborted]`.trim(), exitCode: code ?? 1 });
-          return;
-        }
-        resolvePromise({ output: out, exitCode: code ?? 0 });
-      });
+        signal?.removeEventListener('abort', onAbort);
+        settle();
+      };
+      child.on('error', (err) => finish(() => reject(err)));
+      child.on('close', (code) =>
+        finish(() => resolvePromise({ output: out.trim(), exitCode: code ?? 0 })),
+      );
     });
   }
 }


### PR DESCRIPTION
> ⚠️ 叠在 #1 之上(base = `fix/cancel-inflight-tools`),所以 diff 只含进程组这部分改动。**请先合 #1**;若 #1 squash 合并,我再把本 PR rebase 到 main。

## 问题(比 #1 备注里说的严重)

shell 是用 `spawn(zsh, ['-lc', cmd])` 起的,没有独立进程组。所以 `child.kill()` 只 SIGTERM 那个 shell,**它 fork 出的 dev server / watcher / 编译进程是孙子,收不到信号**,变成孤儿:继续占端口、烧 CPU,而且**关掉 app 都带不走**。

这条 bug 同时打穿三条路:
- `LocalSandbox.exec` 的 timeout / 用户 abort(#1 接上了信号,但杀不干净)
- `kill_shell` 工具
- `killAll()`(app 退出清理)—— 它的注释写着 *"so no process is orphaned"*,实际做不到。

换句话说:**当前 Atrium 没有任何一条路能可靠关掉一个 dev server。**

## 改动

- 新增 `kill-tree.ts`:`killProcessTree(child)` —— 子进程用 `detached:true` 起,自己当进程组 leader,signal 负 pid 命中**整组**;先 SIGTERM,grace(4s)后若组还活着再 SIGKILL(应对 trap 掉 SIGTERM 的进程)。grace timer `unref`,liveness 复检避免 SIGKILL 误伤被回收复用的 pid。
- `local.ts`:shell 改 `detached:true`;timeout / abort 都走 `killProcessTree`(替掉 #1 里的 spawn `signal` 选项 —— 那个只杀直接子进程)。
- `background-shells.ts`:同样 `detached:true`,`kill()` → `killProcessTree`,一并修好 `kill_shell` 和 `killAll`。

## 测试(真·spawn,不是 mock)

`kill-tree.test.ts`:
- **孙子进程被杀**:shell `&` 后台 fork 一个子进程把自己 pid 写文件,读出来确认存活 → `killProcessTree` → 断言该 pid 被回收(轮询)。这条用例在改之前会失败(孤儿存活)。
- **SIGKILL 升级**:`trap '' TERM; sleep 30` 忽略 SIGTERM,grace 设 200ms,断言进程仍被杀掉(只可能是 SIGKILL)。

全量:lint clean、typecheck clean、305/305 pass。

## 复现建议(你晚上验)

改之前:让 agent 前台或后台跑 `npm run dev`,中断 / `kill_shell` / 退出 app,然后 `lsof -i :5173` 看 node 是否还在。改之后应为空。

🤖 Generated with [Claude Code](https://claude.com/claude-code)