### PR TITLE
fix: stop touching the OS keychain on app launch

### DIFF
--- a/src/main/agent/memory/scheduler.ts
+++ b/src/main/agent/memory/scheduler.ts
@@ -17,12 +17,22 @@ export type DreamScheduler = {
 
 /** One pass: consolidate every memory dir that's due, each guarded by the lock. */
 export async function dreamSweep(opts: DreamScheduler, now: number): Promise<void> {
-  const model = opts.model();
-  if (!model) return;
   const dirs = await (opts.listDirs ?? listMemoryDirs)();
+  let model: LanguageModel | null = null;
   for (const dir of dirs) {
     if (!(await shouldConsolidate(dir, now))) continue;
     if (!(await acquireLock(dir, now))) continue;
+    // Resolve the model only once a dir is actually due and locked. model()
+    // decrypts the provider key, which reaches into the OS keychain; resolving it
+    // up-front would prompt for keychain access on every idle sweep — including
+    // the one that runs at app launch, when nothing needs consolidating.
+    if (model === null) {
+      model = opts.model();
+      if (!model) {
+        await releaseLock(dir);
+        return;
+      }
+    }
     void opts
       .runDream(dir, model)
       .catch((err) => log.error(`dream failed: ${dir}`, err))

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,14 +3,14 @@ import { mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { electronApp, is, optimizer } from '@electron-toolkit/utils';
-import { app, BrowserWindow, safeStorage, shell } from 'electron';
+import { app, BrowserWindow, shell } from 'electron';
 import { createIPCHandler } from 'electron-trpc/main';
 import icon from '../../resources/icon.png?asset';
 import { runDream, startDreamScheduler } from './agent/memory';
 import { populateModelCatalog, startModelCatalogRefresh } from './agent/models/catalog';
 import { refreshSkills } from './agent/skills/registry';
 import { closeDb, openDb } from './db';
-import { createLogger, initLogging } from './log';
+import { initLogging } from './log';
 import { resolveModel } from './providers/resolve';
 import { type ChatEndpoint, startHttpServer } from './server/http';
 import { getSettings, openSettings } from './settings/conf';
@@ -81,12 +81,6 @@ app.whenReady().then(async () => {
   // snapshot), then let it refresh from the litellm catalog in the background.
   populateModelCatalog();
   startModelCatalogRefresh();
-
-  if (!safeStorage.isEncryptionAvailable()) {
-    createLogger('app').warn(
-      'safeStorage encryption unavailable — provider credential writes will throw.',
-    );
-  }
 
   // Fallback workspace root for projectless conversations; project-scoped
   // threads run in their project's directory instead, resolved per request.


### PR DESCRIPTION
## Problem

The packaged macOS app prompted for keychain access (**"Atrium Safe Storage"**) on **every launch**, before the user did anything — which reads as malware-like behavior.

The provider API key is encrypted at rest with Electron `safeStorage` (master key in the OS keychain). That design is correct and stays. The bug was *when* we reached into the keychain: **two code paths touched it during startup.**

## Root cause (two startup triggers)

1. **`src/main/index.ts`** — an eager `safeStorage.isEncryptionAvailable()` at boot, purely to log a warning. On macOS the first `safeStorage` call initializes the key from the keychain, so this alone prompts. It's also redundant — `encryptCredentials()` already checks before any write.
2. **`src/main/agent/memory/scheduler.ts`** — the dream scheduler runs one sweep on `app.whenReady()`, and `dreamSweep` resolved the consolidation model (`opts.model()` → `resolveModel` → `decryptCredentials`) **up-front, before** checking whether any memory dir was due. So every launch decrypted the key even when there was nothing to consolidate.

## Fix

- Remove the diagnostic `isEncryptionAvailable()` check (and now-unused imports).
- Reorder `dreamSweep` to resolve the model **lazily** — only once a dir is past the consolidation gates *and* locked (release the lock + bail if no model is configured).

**Result:** a fresh launch with nothing to consolidate never touches the keychain. Access happens only when the user saves an API key, sends a chat / lists models, or a dream is genuinely due.

This is orthogonal to code signing — a Developer ID + notarization (separate, upcoming) still makes the eventual prompt one-time. This PR removes the *at-startup* access.

## Note / remaining edge

If a dream is genuinely due right at launch (memory accumulated in prior sessions), the sweep will still decrypt then — but that's tied to real work, not an unconditional boot access, and won't re-prompt once signed + granted.

## Verification

- ✅ `bun run check` (biome + typecheck)
- ✅ `bun test` — 361 pass / 0 fail (memory scheduler tests: 29 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)