### PR TITLE
fix(chat): 防止快速点击导致重复创建对话

### DIFF
--- a/src/renderer/src/lib/use-onboarding.ts
+++ b/src/renderer/src/lib/use-onboarding.ts
@@ -1,4 +1,5 @@
 import { useNavigate } from '@tanstack/react-router';
+import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePendingInput } from '../state/pending-input-store';
 import { trpc } from './trpc';
@@ -12,14 +13,23 @@ export function useStartOnboarding(): { start: () => void; isPending: boolean } 
   const { t } = useTranslation();
   const navigate = useNavigate();
   const utils = trpc.useUtils();
+  // Synchronous re-entrancy lock: the mutation's isLoading only flips on the
+  // next render, so a rapid second click would slip past a disabled-prop guard
+  // and mint a second thread. A ref blocks it in the same tick.
+  const startedRef = useRef(false);
   const createThread = trpc.threads.create.useMutation({
     onSuccess: async ({ id }) => {
       await utils.threads.list.invalidate();
       navigate({ to: '/chat/$threadId', params: { threadId: id } });
     },
+    onError: () => {
+      startedRef.current = false;
+    },
   });
 
   const start = (): void => {
+    if (startedRef.current) return;
+    startedRef.current = true;
     usePendingInput
       .getState()
       .set({ text: '<skill-use>get-acquainted</skill-use>', attachments: [] });

--- a/src/renderer/src/routes/_app/index.tsx
+++ b/src/renderer/src/routes/_app/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { Handshake, MessageCircle } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Attachment } from '../../components/chat/composer/AttachmentChip';
 import { Composer } from '../../components/chat/composer/Composer';
@@ -64,16 +64,24 @@ function HomeView(): React.JSX.Element {
 
   // Create an empty thread, stash the typed text as a draft, then navigate;
   // the chat view auto-sends the draft once its model is ready.
+  // The ref is a synchronous re-entrancy lock: isLoading only flips next render,
+  // so a rapid second submit would otherwise create a duplicate thread.
+  const submittingRef = useRef(false);
   const createThread = trpc.threads.create.useMutation({
     onSuccess: async ({ id }) => {
       await utils.threads.list.invalidate();
       navigate({ to: '/chat/$threadId', params: { threadId: id } });
+    },
+    onError: () => {
+      submittingRef.current = false;
     },
   });
 
   const handleSubmit = (text: string, attachments: Attachment[]): void => {
     const trimmed = text.trim();
     if (trimmed.length === 0 && attachments.length === 0) return;
+    if (submittingRef.current) return;
+    submittingRef.current = true;
     usePendingInput.getState().set({ text: trimmed, attachments });
     const title = trimmed || attachments[0]?.name || t('home.newChat');
     createThread.mutate({ title: title.slice(0, 60), projectId: projectId ?? undefined });


### PR DESCRIPTION
## Bug

新电脑首页点击「认识一下」会创建 **两个** 对话(见反馈截图,侧栏出现两条 "认识一下" 都是 now)。

## 根因

`useStartOnboarding().start()` 调 `threads.create` mutation 时**没有同步防重入锁**。唯一的保护是按钮的 `disabled={isLoading}`,但 React Query 的 `isLoading` 要到**下一次渲染**才变 true —— 所以同一个 tick 内的第二次触发会绕过 disabled,服务端每次 `create` 都 `randomUUID()` 新插一行 → 两个对话。冷启动首次交互往返慢时窗口更大,更容易复现。

> 注:不是 StrictMode —— StrictMode 只在 dev 生效、且从不重复触发事件回调;这是 production 包里出现的问题。

服务端已核对:`threads.create` 是单次 insert,无重试/重复插入,所以重复一定来自客户端两次 mutate。全仓只有两处 `threads.create.useMutation` 调用点,都有同样的隐患。

## 改动

给两处都加同步 `useRef` 防重入锁(进入时同步置位,`onError` 时复位以便失败后可重试):

- `use-onboarding.ts` `start()` —— 即本次 bug 的「认识一下」;改共享 hook 顺带覆盖设置页的「重新认识一下」
- `index.tsx` `handleSubmit()` —— 首页输入框提交,同样的隐患(快速双发会重复建对话)

成功后会 navigate 离开首页、组件卸载,ref 自然丢弃;失败则复位。正常单次提交行为不变。这个锁拦的是「第二次 mutate」本身,所以无论第二次由什么触发(双击/重复事件)都能挡住。

## 验证

- `bun run check`(biome + tsc)✅ 全过
- 防重入逻辑是同步 check-and-set,逻辑上严密;正常流程因 ref 自清而不受影响
- ⚠️ 没在本地跑竞态复现:「认识一下」按钮只在 `needsOnboarding`(全新 profile)时出现,本机 profile 已初始化,不便去动你的真实 DB。建议你 merge 后在新电脑上再点一次确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)