### PR TITLE
feat(agent): inject the active permission mode as a first-message reminder

### DIFF
--- a/src/main/agent/middleware/builtins/permission-mode.test.ts
+++ b/src/main/agent/middleware/builtins/permission-mode.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'bun:test';
+import type { PermissionMode } from '@shared/permissions';
+import type { UIMessage } from 'ai';
+import type { RunContext } from '../types';
+import { permissionModeMiddleware } from './permission-mode';
+
+const userMsg = (text: string): UIMessage => ({
+  id: 'u',
+  role: 'user',
+  parts: [{ type: 'text', text }],
+});
+function ctxWith(messages: UIMessage[]): RunContext {
+  return { request: { messages, system: '', tools: {} } } as unknown as RunContext;
+}
+function noteFor(mode?: PermissionMode): string {
+  const ctx = ctxWith([userMsg('hi')]);
+  permissionModeMiddleware(mode ? { mode } : {}).beforeRun?.(ctx);
+  return (ctx.request.messages[0].parts[0] as { text: string }).text;
+}
+
+test('injects a <permission-mode> block ahead of the user text', () => {
+  const ctx = ctxWith([userMsg('hi')]);
+  permissionModeMiddleware({ mode: 'full-access' }).beforeRun?.(ctx);
+  expect((ctx.request.messages[0].parts[0] as { text: string }).text).toContain(
+    '<permission-mode>',
+  );
+  expect((ctx.request.messages[0].parts[1] as { text: string }).text).toBe('hi');
+});
+
+test('defaults to default mode and steers away from asking in prose', () => {
+  const text = noteFor();
+  expect(text).toContain('default mode');
+  expect(text).toContain('ask_clarification');
+});
+
+test('each mode produces a distinct, recognisable note', () => {
+  const d = noteFor('default');
+  const a = noteFor('auto-review');
+  const f = noteFor('full-access');
+  expect(new Set([d, a, f]).size).toBe(3);
+  expect(a).toContain('auto-review mode');
+  expect(a).toContain('reviewer');
+  expect(f).toContain('full-access mode');
+});

--- a/src/main/agent/middleware/builtins/permission-mode.ts
+++ b/src/main/agent/middleware/builtins/permission-mode.ts
@@ -1,0 +1,34 @@
+import { DEFAULT_PERMISSION_MODE, type PermissionMode } from '@shared/permissions';
+import { injectSystemReminder } from '../shared/reminder';
+import type { AgentMiddleware, RunContext } from '../types';
+
+export type PermissionModeOptions = { mode?: PermissionMode };
+
+/**
+ * The gate ENFORCES the permission mode; this note only CALIBRATES how much the
+ * model asks vs. just acts — the gate can't stop it from prompting the user
+ * redundantly or attempting writes that will be blocked. It rides as a
+ * first-message reminder (not the static system prompt) because the mode is
+ * volatile: the user toggles it per task.
+ */
+const MODE_NOTES: Record<PermissionMode, string> = {
+  default:
+    "You're in default mode. Actions inside the workspace run on their own; anything that reaches outside it or looks risky pauses for the user to approve. Don't ask for permission in prose — take the action and let the approval prompt handle it; save ask_clarification for genuine decisions only the user can make.",
+  'auto-review':
+    "You're in auto-review mode. Risky or out-of-workspace actions are vetted by an automatic reviewer instead of interrupting the user, so proceed confidently and don't ask for permission in prose; save ask_clarification for genuine decisions only the user can make.",
+  'full-access':
+    "You're in full-access mode. Every action runs immediately with no approval step — so take extra care with destructive or irreversible operations, since nothing will catch them for you.",
+};
+
+export function permissionModeMiddleware(opts: PermissionModeOptions = {}): AgentMiddleware {
+  const mode = opts.mode ?? DEFAULT_PERMISSION_MODE;
+  return {
+    name: 'permission-mode',
+    beforeRun(ctx: RunContext): void {
+      ctx.request.messages = injectSystemReminder(
+        ctx.request.messages,
+        `<permission-mode>\n${MODE_NOTES[mode]}\n</permission-mode>`,
+      );
+    },
+  };
+}

--- a/src/main/agent/middleware/index.ts
+++ b/src/main/agent/middleware/index.ts
@@ -7,6 +7,10 @@ export {
 export { type InstructionsOptions, instructionsMiddleware } from './builtins/instructions';
 export { type MemoryOptions, memoryMiddleware } from './builtins/memory';
 export { metadataMiddleware } from './builtins/metadata';
+export {
+  type PermissionModeOptions,
+  permissionModeMiddleware,
+} from './builtins/permission-mode';
 export { type PersistFn, persistenceMiddleware } from './builtins/persistence';
 export { type ProfileOptions, profileMiddleware } from './builtins/profile';
 export { type SkillsOptions, skillsMiddleware } from './builtins/skills';

--- a/src/main/server/http.ts
+++ b/src/main/server/http.ts
@@ -12,6 +12,7 @@ import {
   instructionsMiddleware,
   memoryMiddleware,
   metadataMiddleware,
+  permissionModeMiddleware,
   persistenceMiddleware,
   profileMiddleware,
   skillsMiddleware,
@@ -239,6 +240,10 @@ export function startHttpServer(deps: {
           persist: persistMessage,
           preservers: [todoPreserver, skillPreserver],
         }),
+        // After compaction (so it lands on the post-compaction first user
+        // message) and ahead of the other injectors, so the operating mode sits
+        // at the bottom of the reminder stack, right above the user's request.
+        permissionModeMiddleware({ mode }),
         skillsMiddleware({ skills }),
         // Run skills → memory → instructions so the injected blocks end up ordered
         // custom-instructions → memory → skills after each prepend.


### PR DESCRIPTION
## 背景

这是 PR #8（system prompt 初稿）里标记的 follow-up（skeleton 第 8 段）。gate 已经在执行权限模式，但模型本身不知道自己处在哪个模式——于是会去问一个 gate 本来就会放行的权限，或者徒劳地尝试一个 gate 会拦的写操作。

## 做了什么

加一个 `permissionModeMiddleware`，在首条 user 消息注入一段 `<permission-mode>` reminder，按当前模式**校准模型的发问/动手程度**（gate 负责 enforce，prompt 只负责 calibrate）：

- **default** —— 工作区内的操作自己跑；越界/有风险的会弹审批卡。别在正文里求权限，直接做、让卡处理；ask_clarification 只留给真正属于用户的决策。
- **auto-review** —— 风险/越界操作交给自动 reviewer 而非打断用户，放手做、别正文求权限。
- **full-access** —— 一切立即执行、没有审批步骤，所以对破坏性/不可逆操作格外小心，没人替你兜底。

## 为什么走 middleware 而不是 buildSystemPrompt 传参

mode 是**易变态**（用户按任务随手切 3 档），走首条消息 reminder 才能让静态 system prompt 保持字节不变、继续命中 prefix cache——和 profile / memory / instructions / skills 这 4 个易变上下文同一条路、同一个机制。mode 在调用处按 turn 解析（http.ts 已有 `const mode = permissionMode ?? DEFAULT_PERMISSION_MODE`），所以 reminder 永远反映当前设置。

放置：compaction 之后（落到压缩后的首条 user 消息）、其它注入器之前，让操作模式落在 reminder 栈底、紧贴用户请求；`<user-profile>` 仍在最上。

## 改动文件

- `src/main/agent/middleware/builtins/permission-mode.ts` —— 新中间件 + 3 档文案。
- `src/main/agent/middleware/builtins/permission-mode.test.ts` —— 注入位置、默认档、三档各异。
- `src/main/agent/middleware/index.ts` —— 导出。
- `src/main/server/http.ts` —— 接入中间件链（传当前 `mode`）。

## 验证

- 中间件全套 51 pass；`biome check` + 全量 typecheck（node + web）clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)