### PR TITLE
fix(chat): keep a manually stopped thread from showing the unread dot

### DIFF
--- a/src/main/agent/middleware/builtins/persistence.test.ts
+++ b/src/main/agent/middleware/builtins/persistence.test.ts
@@ -3,18 +3,38 @@ import type { Db } from '../../../db';
 import type { RunContext, RunResultInfo } from '../types';
 import { persistenceMiddleware } from './persistence';
 
-test('afterRun persists the assistant message with the run thread + db', async () => {
-  const calls: Array<{ db: Db; threadId: string; message: RunResultInfo['message'] }> = [];
-  const mw = persistenceMiddleware((db, threadId, message) => {
-    calls.push({ db, threadId, message });
-  });
+type Captured = {
+  db: Db;
+  threadId: string;
+  message: RunResultInfo['message'];
+  opts?: { markRead?: boolean };
+};
 
-  const db = { tag: 'db' } as unknown as Db;
-  const ctx = { threadId: 't1', db } as unknown as RunContext;
-  const message = { id: 'm1', role: 'assistant', parts: [] } as RunResultInfo['message'];
+function capture(): { calls: Captured[]; mw: ReturnType<typeof persistenceMiddleware> } {
+  const calls: Captured[] = [];
+  const mw = persistenceMiddleware((db, threadId, message, opts) => {
+    calls.push({ db, threadId, message, opts });
+  });
+  return { calls, mw };
+}
+
+const db = { tag: 'db' } as unknown as Db;
+const ctx = { threadId: 't1', db } as unknown as RunContext;
+const message = { id: 'm1', role: 'assistant', parts: [] } as RunResultInfo['message'];
+
+test('afterRun persists the assistant message with the run thread + db', async () => {
+  const { calls, mw } = capture();
 
   await mw.afterRun?.(ctx, { message });
 
   expect(calls).toHaveLength(1);
-  expect(calls[0]).toEqual({ db, threadId: 't1', message });
+  expect(calls[0]).toEqual({ db, threadId: 't1', message, opts: { markRead: undefined } });
+});
+
+test('afterRun marks a user-aborted turn as read so it skips the unread dot', async () => {
+  const { calls, mw } = capture();
+
+  await mw.afterRun?.(ctx, { message, aborted: true });
+
+  expect(calls[0]?.opts).toEqual({ markRead: true });
 });

--- a/src/main/agent/middleware/builtins/persistence.ts
+++ b/src/main/agent/middleware/builtins/persistence.ts
@@ -2,18 +2,28 @@ import type { UIMessage } from 'ai';
 import type { Db } from '../../../db';
 import type { AgentMiddleware } from '../types';
 
-export type PersistFn = (db: Db, threadId: string, message: UIMessage) => void;
+export type PersistFn = (
+  db: Db,
+  threadId: string,
+  message: UIMessage,
+  opts?: { markRead?: boolean },
+) => void;
 
 /**
  * Persists the completed assistant message when the turn ends. The persister is
  * injected so the agent layer doesn't depend on the server layer (the assembly
  * site supplies the real persistMessage).
+ *
+ * A user-initiated stop is the viewer deciding the turn is done, so it counts as
+ * read: persist the partial message as read, otherwise its updatedAt bump would
+ * trip the sidebar's unread dot on the very thread the user is looking at (the
+ * client's mark-read races this write and usually loses).
  */
 export function persistenceMiddleware(persist: PersistFn): AgentMiddleware {
   return {
     name: 'persistence',
     afterRun(ctx, result) {
-      persist(ctx.db, ctx.threadId, result.message);
+      persist(ctx.db, ctx.threadId, result.message, { markRead: result.aborted });
     },
   };
 }

--- a/src/main/agent/middleware/types.ts
+++ b/src/main/agent/middleware/types.ts
@@ -62,7 +62,11 @@ export type ToolCallInfo = { name: ToolName; input: unknown; toolCallId: string 
 /** beforeToolUse returns this to skip execution and use `result` instead. */
 export type ToolShortCircuit = { result: unknown };
 
-export type RunResultInfo = { message: UIMessage };
+export type RunResultInfo = {
+  message: UIMessage;
+  /** The turn ended because the user stopped it, not because the model finished. */
+  aborted?: boolean;
+};
 
 /** The stream part messageMetadata receives — streamText's fullStream element. */
 export type MetadataPart = TextStreamPart<ToolSet>;

--- a/src/main/agent/run.ts
+++ b/src/main/agent/run.ts
@@ -87,8 +87,8 @@ export async function runAgent(opts: RunAgentOptions): Promise<ReadableStream<UI
     // Surface the real failure to the client (default masks it). The renderer
     // reads useChat's `error` and shows it instead of silently stalling.
     onError: readableError,
-    onFinish: ({ responseMessage }) =>
-      runAfterRun(ctx, { message: responseMessage }, opts.middlewares),
+    onFinish: ({ responseMessage, isAborted }) =>
+      runAfterRun(ctx, { message: responseMessage, aborted: isAborted }, opts.middlewares),
     execute: async ({ writer }) => {
       ctx.emit = (event) => writer.write(event);
       await runBeforeRun(ctx, opts.middlewares);

--- a/src/main/server/persist.ts
+++ b/src/main/server/persist.ts
@@ -71,7 +71,12 @@ export function persistMessage(db: Db, threadId: string, msg: UIMessage): void {
  * answer (the AI SDK extends it under the same id rather than minting a new
  * one). Insert-and-ignore would silently drop the continuation.
  */
-export function upsertMessage(db: Db, threadId: string, msg: UIMessage): void {
+export function upsertMessage(
+  db: Db,
+  threadId: string,
+  msg: UIMessage,
+  opts?: { markRead?: boolean },
+): void {
   db.insert(messages)
     .values({
       id: msg.id,
@@ -85,7 +90,12 @@ export function upsertMessage(db: Db, threadId: string, msg: UIMessage): void {
       set: { parts: msg.parts, metadata: msg.metadata ?? null },
     })
     .run();
-  db.update(threads).set({ updatedAt: new Date() }).where(eq(threads.id, threadId)).run();
+  const now = new Date();
+  // markRead stamps lastReadAt = updatedAt so this write can't trip the sidebar's
+  // unread dot — used when the user stops a turn, since the partial message is
+  // persisted on a thread they're actively viewing.
+  const bump = opts?.markRead ? { updatedAt: now, lastReadAt: now } : { updatedAt: now };
+  db.update(threads).set(bump).where(eq(threads.id, threadId)).run();
 }
 
 /** The user's ACP launch overrides for a local-cli provider (blank = manifest default). */


### PR DESCRIPTION
## 问题

中断对话（Stop 按钮 / Esc）后，侧边栏会在你刚手动停掉的那个会话上重新冒出蓝色未读点——但这是你主动取消的，不应被当作未读。

## 根因：标记已读 vs 中断落库的时序竞态

侧边栏未读判定为 `updatedAt > lastReadAt`（`ThreadRow.tsx:36`）。

- **正常结束**：服务端先把回答落库刷新 `updatedAt` → 流关闭 → 客户端状态变 `ready` → `markRead` 写更晚的 `lastReadAt` → 不显示点。
- **中断 / Esc**：`onStop` 先调 `stop()`（`$threadId.tsx:121`），AI SDK 的 `stop()` **立刻**把客户端 status 翻成 `ready`，马上触发 `markRead`；之后 `/abort` 请求才到服务端，中止 agent loop，`onFinish` 把「半截回答」落库，`upsertMessage` 又把 `updatedAt` 刷成更晚的时间（`persist.ts`）。结果 `updatedAt > lastReadAt` → 未读点重现。

一句话：中断时「客户端标记已读」跑在前、「服务端落库刷新 updatedAt」跑在后，顺序反了。

## 修复

把流的 `isAborted` 经 run 结果透传给 persistence 中间件；用户主动中断时，落这条半截消息的同时把 `lastReadAt = updatedAt` 一起写（沿用现有「用户自己发消息算已读」的规则，`persist.ts:59-62`）。

两者在同一条 `update().set()` 里原子写入，使结果与执行顺序无关：客户端的 `markRead` 只会把 `lastReadAt` 往后推，所以任意交错最终都满足 `lastReadAt >= updatedAt` → 不显示未读点，且导航离开后也不会再冒出来。

## 测试

- 新增用例：中断的 turn 落库时带 `markRead: true`；正常 turn 不带。
- `bun test` 全绿（403 passed），`typecheck:node` + `biome` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)