### PR TITLE
feat(agent): anchor today via a per-turn reminder on the latest user turn

### DIFF
--- a/src/main/agent/middleware/builtins/date.test.ts
+++ b/src/main/agent/middleware/builtins/date.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'bun:test';
+import type { UIMessage } from 'ai';
+import type { RunContext } from '../types';
+import { dateMiddleware } from './date';
+
+const user = (id: string, text: string): UIMessage => ({
+  id,
+  role: 'user',
+  parts: [{ type: 'text', text }],
+});
+const textOf = (m: UIMessage, i: number) => (m.parts[i] as { text: string }).text;
+
+function ctxWith(messages: UIMessage[]): RunContext {
+  return { request: { messages } } as unknown as RunContext;
+}
+
+// Local-time constructors (not UTC strings): currentDateNote formats in the
+// machine's local zone, so building the Date in that same zone makes the asserted
+// calendar date deterministic on any machine.
+
+test('injects a day-granular date reminder onto the latest user turn', async () => {
+  const ctx = ctxWith([user('u1', 'yesterday'), user('u2', 'today')]);
+  await dateMiddleware(() => new Date(2026, 5, 30, 12, 0, 0)).beforeRun?.(ctx);
+
+  const [first, last] = ctx.request.messages;
+  expect(first.parts).toHaveLength(1); // earlier turn untouched → stays cacheable
+  expect(textOf(last, 0)).toContain('<system-reminder>');
+  expect(textOf(last, 0)).toContain("Today's date is 2026-06-30");
+  expect(textOf(last, 1)).toBe('today');
+});
+
+test('recomputes per call, so a later turn reflects a crossed-midnight date', async () => {
+  let now = new Date(2026, 5, 30, 23, 59, 0);
+  const mw = dateMiddleware(() => now);
+
+  const ctx1 = ctxWith([user('u1', 'before midnight')]);
+  await mw.beforeRun?.(ctx1);
+  expect(textOf(ctx1.request.messages[0], 0)).toContain('2026-06-30');
+
+  now = new Date(2026, 6, 1, 0, 1, 0);
+  const ctx2 = ctxWith([user('u2', 'after midnight')]);
+  await mw.beforeRun?.(ctx2);
+  expect(textOf(ctx2.request.messages[0], 0)).toContain('2026-07-01');
+});

--- a/src/main/agent/middleware/builtins/date.ts
+++ b/src/main/agent/middleware/builtins/date.ts
@@ -1,0 +1,22 @@
+import { currentDateNote } from '../../prompts';
+import { injectSystemReminder } from '../shared/reminder';
+import type { AgentMiddleware, RunContext } from '../types';
+
+/**
+ * Anchors "today" so the model doesn't fall back to its training cutoff (e.g.
+ * searching for last year's data). The note rides on the latest user turn rather
+ * than the system prompt, which keeps the cached system prefix byte-stable, and
+ * it's recomputed every turn — so a conversation that crosses midnight picks up
+ * the new date on its next message with no explicit staleness tracking. `now` is
+ * injectable for tests.
+ */
+export function dateMiddleware(now: () => Date = () => new Date()): AgentMiddleware {
+  return {
+    name: 'date',
+    beforeRun(ctx: RunContext): void {
+      ctx.request.messages = injectSystemReminder(ctx.request.messages, currentDateNote(now()), {
+        anchor: 'last',
+      });
+    },
+  };
+}

--- a/src/main/agent/middleware/index.ts
+++ b/src/main/agent/middleware/index.ts
@@ -4,6 +4,7 @@ export {
   compactionMiddleware,
   compactThread,
 } from './builtins/compaction';
+export { dateMiddleware } from './builtins/date';
 export { type InstructionsOptions, instructionsMiddleware } from './builtins/instructions';
 export { type MemoryOptions, memoryMiddleware } from './builtins/memory';
 export { metadataMiddleware } from './builtins/metadata';

--- a/src/main/agent/middleware/shared/reminder.test.ts
+++ b/src/main/agent/middleware/shared/reminder.test.ts
@@ -30,6 +30,19 @@ test('targets the first user message past leading assistant turns', () => {
   expect(textOf(out[1], 0)).toContain('R');
 });
 
+test("anchor 'last' targets the most recent user turn, leaving earlier ones untouched", () => {
+  const first = user('first');
+  const assistant: UIMessage = { id: 'a', role: 'assistant', parts: [{ type: 'text', text: 'a' }] };
+  const last = user('latest');
+  const out = injectSystemReminder([first, assistant, last], 'R', { anchor: 'last' });
+
+  expect(out[0]).toBe(first); // earlier user turn stays cacheable
+  expect(out[1]).toBe(assistant);
+  expect(out[2].parts).toHaveLength(2);
+  expect(textOf(out[2], 0)).toContain('R');
+  expect(textOf(out[2], 1)).toBe('latest');
+});
+
 test('non-destructive: original message and array untouched', () => {
   const orig = user('hello');
   const input = [orig];

--- a/src/main/agent/middleware/shared/reminder.ts
+++ b/src/main/agent/middleware/shared/reminder.ts
@@ -1,9 +1,23 @@
 import type { UIMessage } from 'ai';
 
-// On the user message (not the system prompt) so a changing index keeps the prompt cache.
-// Cloned, not mutated, so it never leaks into the persisted/UI messages.
-export function injectSystemReminder(messages: UIMessage[], inner: string): UIMessage[] {
-  const idx = messages.findIndex((m) => m.role === 'user');
+/**
+ * Prepend a <system-reminder> to a user message — on the message, not the system
+ * prompt, so the system prefix stays cacheable. Cloned, not mutated, so it never
+ * leaks into the persisted/UI messages.
+ *
+ * anchor 'first' (default) targets the earliest user turn — right for stable
+ * per-conversation context (memory, skills, instructions): identical across turns,
+ * so it rides inside the cached prefix without churning it. anchor 'last' targets
+ * the current turn — right for content that changes every turn (the date), keeping
+ * that volatile value on the uncached tail.
+ */
+export function injectSystemReminder(
+  messages: UIMessage[],
+  inner: string,
+  opts: { anchor?: 'first' | 'last' } = {},
+): UIMessage[] {
+  const isUser = (m: UIMessage): boolean => m.role === 'user';
+  const idx = opts.anchor === 'last' ? messages.findLastIndex(isUser) : messages.findIndex(isUser);
   if (idx < 0) return messages;
 
   const text = `<system-reminder>\n${inner}\n</system-reminder>`;

--- a/src/main/agent/prompts/index.ts
+++ b/src/main/agent/prompts/index.ts
@@ -1,1 +1,1 @@
-export { buildSystemPrompt, workspaceGuidance } from './system';
+export { buildSystemPrompt, currentDateNote, workspaceGuidance } from './system';

--- a/src/main/agent/prompts/system.test.ts
+++ b/src/main/agent/prompts/system.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test';
-import { buildSystemPrompt, workspaceGuidance } from './system';
+import { buildSystemPrompt, currentDateNote, workspaceGuidance } from './system';
 
 test('opens with the broad Atrium identity, not a coding-only or Mac-bound one', () => {
   const p = buildSystemPrompt('/tmp/ws');
@@ -37,6 +37,18 @@ test('injects the soul with a precedence note over the style guidance', () => {
   expect(p).toContain('takes precedence');
   // No empty soul tags when absent.
   expect(buildSystemPrompt('/tmp/ws')).not.toContain('<soul>');
+});
+
+test('the date is not baked into the system prompt (it rides a per-turn reminder instead)', () => {
+  expect(buildSystemPrompt('/tmp/ws')).not.toContain("Today's date is");
+});
+
+test('currentDateNote renders a day-granular anchor and tells the model to prefer today', () => {
+  const note = currentDateNote(new Date('2026-06-15T12:00:00Z'));
+  expect(note).toMatch(/Today's date is \d{4}-\d{2}-\d{2} \(\w+, .+\)\./);
+  // Noon UTC reads as 2026 in every time zone, so the year is assertable cross-machine.
+  expect(note).toContain('2026');
+  expect(note).toMatch(/training cutoff/i);
 });
 
 test('does not re-explain individual tools (their descriptions own that)', () => {

--- a/src/main/agent/prompts/system.ts
+++ b/src/main/agent/prompts/system.ts
@@ -9,6 +9,26 @@ export function workspaceGuidance(workspaceRoot: string): string {
 File and shell tools default to this directory — address files with absolute paths (e.g. ${workspaceRoot}/notes.txt), and relative paths resolve against it. You can read files anywhere on the machine; writing outside the workspace asks the user for approval.`;
 }
 
+/**
+ * A day-granular "today" anchor. Without it, models reason from their training
+ * cutoff — e.g. searching for last year's data or assuming the wrong current year.
+ * Day granularity (no clock time) is all the model needs here and keeps the line
+ * short; dateMiddleware injects it per turn onto the latest user message (not the
+ * system prompt), so it stays off the cached prefix and refreshes across midnight.
+ * Formatted in the machine's local time zone, since "today" is the user's local day.
+ */
+export function currentDateNote(now: Date): string {
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const date = new Intl.DateTimeFormat('en-CA', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    timeZone,
+  }).format(now);
+  const weekday = new Intl.DateTimeFormat('en-US', { weekday: 'long', timeZone }).format(now);
+  return `Today's date is ${date} (${weekday}, ${timeZone}). Your training cutoff is earlier, so treat today as ground truth for anything time-sensitive — don't assume the current year or carry a stale one into web searches, "latest"/"current" lookups, or date math.`;
+}
+
 function platformLabel(platform: NodeJS.Platform): string {
   switch (platform) {
     case 'darwin':

--- a/src/main/agent/subagent/run.ts
+++ b/src/main/agent/subagent/run.ts
@@ -3,8 +3,9 @@ import { convertToModelMessages, generateId, stepCountIs, streamText, type UIMes
 import { recordUsage, tokenCountsOf } from '../../db/usage';
 import { createLogger } from '../../log';
 import { compactionMiddleware, composeBeforeStep, type RunContext } from '../middleware';
+import { injectSystemReminder } from '../middleware/shared/reminder';
 import type { ModelPricing } from '../models/types';
-import { workspaceGuidance } from '../prompts';
+import { currentDateNote, workspaceGuidance } from '../prompts';
 import { todoPreserver } from '../tools/builtins/todo';
 import { filterToolsForSubagent, type SubagentDef } from './defs';
 
@@ -66,9 +67,10 @@ export async function runSubagent(opts: RunSubagentOptions): Promise<SubagentRes
 
   const tools = filterToolsForSubagent(parent.request.tools, agent);
   const system = `${agent.systemPrompt}\n\n${workspaceGuidance(parent.workspaceRoot)}`;
-  const messages: UIMessage[] = [
-    { id: generateId(), role: 'user', parts: [{ type: 'text', text: prompt }] },
-  ];
+  const messages: UIMessage[] = injectSystemReminder(
+    [{ id: generateId(), role: 'user', parts: [{ type: 'text', text: prompt }] }],
+    currentDateNote(new Date()),
+  );
 
   const subCtx: RunContext = {
     threadId: parent.threadId,

--- a/src/main/server/http.ts
+++ b/src/main/server/http.ts
@@ -11,6 +11,7 @@ import { buildMcpTools } from '../agent/mcp/tool-adapter';
 import {
   compactionMiddleware,
   compactThread,
+  dateMiddleware,
   instructionsMiddleware,
   memoryMiddleware,
   metadataMiddleware,
@@ -255,6 +256,10 @@ export function startHttpServer(deps: {
         instructionsMiddleware(),
         // Last injector → its block lands on top: <user-profile> above the rest.
         profileMiddleware(),
+        // Anchors today on the current turn's user message (its own anchor, the
+        // last user turn), so it stays off the cached prefix the others share and
+        // refreshes every turn — keeping a cross-midnight conversation current.
+        dateMiddleware(),
         // Upsert, not insert-ignore: when a turn resumes after an
         // ask_clarification answer, the model extends the SAME assistant message
         // (reused id), and that continuation must overwrite the stored copy.


### PR DESCRIPTION
## 问题

普通模型在 system prompt 没有「当前日期」概念时会退回训练截止年份——比如给联网搜索补一个过期年份(明明 2026 了还搜「…2025」)。

## 方案(调研后选定)

注入一行日粒度的 `Today's date is …` 锚点,但**放在每轮最新的 user 消息上**(作为 `<system-reminder>`),而不是写进 system prompt:

- **system 前缀字节不变** → 跨 provider 的自动前缀缓存全程命中(普通模型多走自动缓存,这点尤其值);易变的日期落在不缓存的尾部。
- **每轮用 `new Date()` 重算** → 会话跨午夜时,下一条消息自动拿到新日期,无需任何显式过期/午夜检测。
- 子智能体(deep-research 会联网搜)在自己的 prompt 上拿到同一锚点。

`injectSystemReminder` 新增 `anchor` 选项:`first`(默认,稳定上下文留在缓存前缀里)、`last`(易变的日期贴到当前轮)。

实际一轮发出去长这样(锚点在最新 user 消息,早先的 user 消息不动 → 保持可缓存):

```
user      :: older question
assistant :: an answer
user      :: <system-reminder>
Today's date is 2026-06-30 (Tuesday, Asia/Shanghai). Your training cutoff is earlier, so treat today as ground truth ... don't ... carry a stale one into web searches ...
</system-reminder> | 长鑫什么时候上市
```

## 为什么这么放(调研结论)

横向调研 DeerFlow / Claude Code / Aider / Cline / OpenHands / Continue / gptme / Codex / Goose 后的共识:

- **DeerFlow 2.0**(正是此前提到的那个)用 `DynamicContextMiddleware` 把日期作为独立 `<system-reminder>` 注入(date-only),每轮注入并显式处理跨午夜。
- **Claude Code / claude.ai**:日期只到「天」,且刻意从冻结的 system prompt 移到 system-reminder,就为了保缓存。
- **Goose / Codex / OpenHands**:都把易变时间挪到缓存断点之后(最新 user 消息 / 独立块),只到「天」或「分」,从不在缓存区放秒级时钟。

本 PR 取这套做法里对 Atrium 最简的形态:每轮一条小 reminder 贴最新 user 消息,跨天天然解决,省掉 DeerFlow 那套去重+午夜检测的复杂度(那主要是为它捆绑的「记忆+日期」reminder 去重)。

> 注:此前讨论的「给每条历史消息打时间戳」是更进阶的一档(让模型推理『这句是哪天问的』),全行业基本无人实现,本 PR 暂不做。

## 测试

- `date.ts` 中间件:注入到最新 user 消息、早先 user 消息不动、跨午夜重算。
- `reminder.ts`:新增 `anchor: 'last'` 用例。
- `system.ts`:断言日期**不再**进 system prompt;`currentDateNote` 形状/年份/训练截止措辞。
- `bun test` 全绿(408 passed)· `typecheck:node` · `biome` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)