### PR TITLE
build(macos): sign + notarize releases across arm64 and x64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Build each macOS arch on its own native runner: macos-latest is
+          # Apple Silicon (arm64), macos-13 is Intel (x64). Native runners
+          # rebuild better-sqlite3 / node-pty for their own arch cleanly.
           - os: macos-latest
             platform: mac
+            archFlag: "--arm64"
+          - os: macos-13
+            platform: mac
+            archFlag: "--x64"
           - os: windows-latest
             platform: win
+            archFlag: ""
           - os: ubuntu-latest
             platform: linux
+            archFlag: ""
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -75,8 +84,15 @@ jobs:
         run: bun run build
 
       - name: Package and publish
-        run: bunx electron-builder --${{ matrix.platform }} --publish ${{ github.event_name == 'push' && 'always' || 'never' }}
+        run: bunx electron-builder --${{ matrix.platform }} ${{ matrix.archFlag }} --publish ${{ github.event_name == 'push' && 'always' || 'never' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # No Apple signing certs in CI — don't attempt to sign/notarize.
-          CSC_IDENTITY_AUTO_DISCOVERY: false
+          # macOS signing + notarization. These are only populated on the mac
+          # runner; Windows/Linux get empty strings, so electron-builder finds
+          # no cert (CSC_LINK) and no notarize creds and skips both cleanly.
+          # CSC_LINK is the base64 of the Developer ID Application .p12.
+          CSC_LINK: ${{ matrix.platform == 'mac' && secrets.MAC_CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.platform == 'mac' && secrets.MAC_CSC_KEY_PASSWORD || '' }}
+          APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.platform == 'mac' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Build each macOS arch on its own native runner: macos-latest is
-          # Apple Silicon (arm64), macos-13 is Intel (x64). Native runners
-          # rebuild better-sqlite3 / node-pty for their own arch cleanly.
-          - os: macos-latest
+          # Build each macOS arch on its own native runner: macos-15 is
+          # Apple Silicon (arm64), macos-15-intel is the last GitHub-hosted
+          # Intel (x64) image (available through Aug 2027; the old macos-13
+          # Intel runner was retired Dec 2025). Native runners rebuild
+          # better-sqlite3 / node-pty for their own arch cleanly.
+          - os: macos-15
             platform: mac
             archFlag: "--arm64"
-          - os: macos-13
+          - os: macos-15-intel
             platform: mac
             archFlag: "--x64"
           - os: windows-latest
@@ -56,7 +58,7 @@ jobs:
           bun-version: latest
 
       - name: Cache Electron binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/electron

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -31,21 +31,34 @@ asarUnpack:
   # the file resolves on disk rather than from inside the asar archive.
   - node_modules/jieba-wasm/**
 mac:
-  # No Apple Developer ID in CI, so the app is only ad-hoc signed. Hardened
-  # Runtime enforces Library Validation (same Team ID for all nested code),
-  # which an ad-hoc signature can't satisfy — on macOS 14+ that makes dyld
-  # reject Electron Framework at launch ("different Team IDs"). Disable it so
-  # the ad-hoc build launches; re-enable once we sign + notarize with a real ID.
-  hardenedRuntime: false
+  # Signed + notarized with a real Developer ID (Team 43PH2NJ5C4). Hardened
+  # Runtime is mandatory for notarization, and it makes dyld enforce Library
+  # Validation — every nested binary must share that Team ID, which a genuine
+  # signature satisfies. The entitlements below grant the JIT /
+  # unsigned-executable-memory / dyld-env exceptions Electron's V8 needs while
+  # Hardened Runtime is on. Notarization credentials come from the environment
+  # (APPLE_* / APPLE_KEYCHAIN_PROFILE); when none are present — Windows/Linux
+  # runners, or a fork without secrets — electron-builder skips notarization
+  # silently instead of failing.
+  #
+  # arm64 and x64 are each built on their own native CI runner (Apple Silicon
+  # vs Intel), which sidesteps cross-compiling the native modules
+  # (better-sqlite3, node-pty). dmg-only — no zip/auto-update target — so the
+  # two per-arch publish jobs never race on a shared latest-mac.yml.
+  target:
+    - dmg
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
     - NSCameraUsageDescription: Atrium 需要访问相机以支持相关功能。
     - NSMicrophoneUsageDescription: Atrium 需要访问麦克风以支持语音输入。
     - NSDocumentsFolderUsageDescription: Atrium 需要访问"文稿"文件夹以读写工作区文件。
     - NSDownloadsFolderUsageDescription: Atrium 需要访问"下载"文件夹以保存生成的产物。
-  notarize: false
+  notarize: true
 dmg:
-  artifactName: ${name}-${version}.${ext}
+  artifactName: ${name}-${version}-${arch}.${ext}
 win:
   target:
     - nsis

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build": "bun run typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "bun run build && electron-builder --dir",
-    "build:mac": "bun run build && electron-builder --mac",
+    "build:mac": "bun run build && APPLE_KEYCHAIN_PROFILE=atrium-notary electron-builder --mac",
     "build:win": "bun run build && electron-builder --win",
     "build:linux": "bun run build && electron-builder --linux"
   },


### PR DESCRIPTION
Enable Developer ID **signing + notarization** for macOS distribution, covering both **Apple Silicon (arm64)** and **Intel (x64)**.

## Changes
- `electron-builder.yml`: Hardened Runtime + JIT/unsigned-memory/dyld entitlements, `notarize: true`, dmg-only with arch-suffixed name (`atrium-<ver>-<arch>.dmg`).
- `.github/workflows/release.yml`: mac-scoped signing/notarize secrets (Win/Linux skip cleanly); build each mac arch on its own native runner — arm64 on `macos-15`, x64 on `macos-15-intel` — so `better-sqlite3`/`node-pty` compile natively (no cross-compile). `macos-13` (Intel) was retired Dec 2025.
- `package.json`: local `build:mac` notarizes via the `atrium-notary` keychain profile (no plaintext password).

## Validation (CI dry-run, all green)
Run: https://github.com/lhz960904/atrium/actions/runs/28503598266 — test + 4 build jobs all ✅

Both mac jobs logged `notarization successful` and Apple confirmed both submissions `Accepted`:
- arm64 (macos-15) → `atrium-0.0.13-arm64.dmg`
- x64 (macos-15-intel) → `atrium-0.0.13-x64.dmg`

Windows/Linux build unsigned as before.

> Note: this was a dry-run (`--publish never`). A real signed release is cut by pushing a version tag → `--publish always` → draft GitHub Release with the DMGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)