### PR TITLE
fix(providers): return null when stored credentials can't be decrypted

### DIFF
--- a/src/main/trpc/routers/providers.ts
+++ b/src/main/trpc/routers/providers.ts
@@ -116,7 +116,15 @@ export const providersRouter = router({
         .where(eq(providers.id, input.id))
         .get();
       if (!row?.blob) return null;
-      return decryptCredentials<{ key: string }>(row.blob).key;
+      try {
+        return decryptCredentials<{ key: string }>(row.blob).key;
+      } catch {
+        // The blob can't be decrypted — the safeStorage key was removed or
+        // rotated in the OS keychain, so the ciphertext is unrecoverable.
+        // Report it as "no readable credential" so the field falls back to an
+        // empty, editable input and the user can re-enter the key.
+        return null;
+      }
     }),
 
   clearCredentials: publicProcedure


### PR DESCRIPTION
## Problem
When the macOS Keychain entry backing Electron `safeStorage` is removed or rotated (e.g. the user deletes the `atrium Safe Storage` item), `safeStorage.decryptString` throws. `getCredentials` had no guard, so the tRPC query kept rejecting and the provider **API Key field stayed stuck on "加载中…" (loading) forever** — the user couldn't re-enter their key.

## Fix
Treat an undecryptable blob as *no readable credential*: `getCredentials` catches the decrypt failure and returns `null`. The existing `ApiKeyField` `.then(plaintext => setValue(plaintext ?? ''))` then renders an empty, editable input, so the user can simply re-enter the key (which re-encrypts under the current keychain key).

Backend-only change — no frontend edits needed.

## Test
- `bun run check` (lint + typecheck) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)