### PR TITLE
ci(release): search plain v-prefixed tags, not component-prefixed

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Problem
release-please's Release PR (#19) proposed **0.2.0 with the entire project history** re-listed. Cause: in manifest mode it defaulted to component-prefixed tags (`atrium-v0.1.0`), which don't match the repo's real `v0.1.0` tags. Not finding a prior release, it treated everything since the first commit as unreleased.

## Fix
`"include-component-in-tag": false` — release-please now searches for plain `v*` tags, finds `v0.1.0`, and only counts commits since it. After this merges, #19 should auto-close (nothing releasable since v0.1.0 except `ci:` commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)