### PR TITLE
perf(startup): move login-shell env and skill scan off first paint

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -108,29 +108,54 @@ app.whenReady().then(async () => {
   // we set ours explicitly; packaged macOS builds already carry build/icon.icns.
   if (process.platform === 'darwin') app.dock?.setIcon(icon);
   initLogging();
-  // Load the user's real login-shell environment before anything spawns (MCP stdio
-  // servers, shells), so PATH and their exported vars match what the terminal has.
-  loadShellEnv();
 
   const db = openDb();
   openSettings();
-
-  // Warm model metadata from the disk cache (falls back to the bundled
-  // snapshot), then let it refresh from the litellm catalog in the background.
-  populateModelCatalog();
-  startModelCatalogRefresh();
-
-  // Connect configured MCP servers in the background so their tools join the
-  // toolset once ready; a slow or failing server never blocks startup.
-  void mcpManager.init(db);
 
   // Fallback workspace root for projectless conversations; project-scoped
   // threads run in their project's directory instead, resolved per request.
   const projectlessRoot = join(homedir(), 'Documents', 'Atrium');
   mkdirSync(projectlessRoot, { recursive: true });
 
-  // Discover skills before serving so the first turn already sees the index.
-  await refreshSkills();
+  // Bring the chat server up first — it's a fast port bind — so the IPC handler
+  // attaches before the window paints and the renderer's first tRPC calls never
+  // race a missing handler.
+  const chatEndpoint = await startHttpServer({ db, token: randomUUID(), projectlessRoot });
+  serverEndpoint = chatEndpoint;
+
+  app.on('browser-window-created', (_, window) => {
+    optimizer.watchWindowShortcuts(window);
+  });
+
+  // Paint the window now. Everything slow or spawn-related below runs off the
+  // critical path, so first paint no longer waits on the login shell (seconds
+  // behind a heavy rc) or the skills scan.
+  const win = createWindow();
+  createIPCHandler({
+    router: appRouter,
+    windows: [win],
+    createContext: async () => ({ db, chatEndpoint }),
+  });
+
+  // Resolve the user's login-shell environment in the background so PATH and
+  // their exported vars match the terminal. It can take seconds behind a slow
+  // rc, so nothing awaits it except the subprocess-spawning init below.
+  const shellEnvReady = loadShellEnv();
+
+  // Warm model metadata from the disk cache (falls back to the bundled
+  // snapshot), then let it refresh from the litellm catalog in the background.
+  populateModelCatalog();
+  startModelCatalogRefresh();
+
+  // Connect configured MCP servers once the shell env is merged — stdio servers
+  // read PATH from process.env at spawn, so they must not start before it. A
+  // slow or failing server never blocks startup.
+  void shellEnvReady.then(() => mcpManager.init(db));
+
+  // Discover skills in the background, off the critical path. The scheduler
+  // (below) waits on this so a boot-time catch-up run still sees the full index;
+  // interactive turns already outlast the scan.
+  const skillsReady = refreshSkills();
 
   // Background memory consolidation (dream) — runs off the conversation path,
   // gated so it only fires for memory that has actually accumulated.
@@ -144,20 +169,6 @@ app.whenReady().then(async () => {
         return null;
       }
     },
-  });
-
-  const chatEndpoint = await startHttpServer({ db, token: randomUUID(), projectlessRoot });
-  serverEndpoint = chatEndpoint;
-
-  app.on('browser-window-created', (_, window) => {
-    optimizer.watchWindowShortcuts(window);
-  });
-
-  const win = createWindow();
-  createIPCHandler({
-    router: appRouter,
-    windows: [win],
-    createContext: async () => ({ db, chatEndpoint }),
   });
 
   // Show (or, after a full quit cycle / non-macOS, rebuild) the main window.
@@ -176,36 +187,39 @@ app.whenReady().then(async () => {
     });
   };
 
-  // Scheduled tasks drive the same chat server headlessly, so start them only
-  // once it's listening. Each task runs with its own model (falling back to the
-  // globally selected one), passed to /api/chat as a request parameter. A
-  // finished run raises a notification whose click reveals the bound thread.
-  startScheduledTasks({
-    db,
-    endpoint: { port: chatEndpoint.port, token: chatEndpoint.token },
-    runningThreadIds: getRunningThreadIds,
-    defaultModel: () => {
-      // The renderer only persists general.selectedModel on an explicit pick, so
-      // it can be null even when the user has a working model — fall back to the
-      // first enabled one so a headless run isn't blocked on "no model".
-      try {
-        return getSettings('general.selectedModel') ?? firstEnabledModel(db);
-      } catch {
-        return null;
-      }
-    },
-    onComplete: (task, run) => {
-      notifyScheduledRun({
-        title: task.title,
-        threadId: task.threadId,
-        status: run.status,
-        onOpen: (threadId) => {
-          showWindow();
-          mainWindow?.webContents.send('scheduled:open-thread', threadId);
-        },
-      });
-    },
-  });
+  // Scheduled tasks drive the same chat server headlessly. Start them once skills
+  // are discovered — the chat server is already listening, and gating on the scan
+  // keeps a boot-time catch-up run from firing before the skill index exists. Run
+  // even if discovery rejects (a failed scan must not strand the scheduler).
+  const startScheduler = (): void => {
+    startScheduledTasks({
+      db,
+      endpoint: { port: chatEndpoint.port, token: chatEndpoint.token },
+      runningThreadIds: getRunningThreadIds,
+      defaultModel: () => {
+        // The renderer only persists general.selectedModel on an explicit pick, so
+        // it can be null even when the user has a working model — fall back to the
+        // first enabled one so a headless run isn't blocked on "no model".
+        try {
+          return getSettings('general.selectedModel') ?? firstEnabledModel(db);
+        } catch {
+          return null;
+        }
+      },
+      onComplete: (task, run) => {
+        notifyScheduledRun({
+          title: task.title,
+          threadId: task.threadId,
+          status: run.status,
+          onOpen: (threadId) => {
+            showWindow();
+            mainWindow?.webContents.send('scheduled:open-thread', threadId);
+          },
+        });
+      },
+    });
+  };
+  void skillsReady.then(startScheduler, startScheduler);
 
   setupMenuBar({
     showWindow,

--- a/src/main/shell-path.ts
+++ b/src/main/shell-path.ts
@@ -1,34 +1,43 @@
-import { execFileSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { createLogger } from './log';
 
 const log = createLogger('shell-path');
 const DELIM = '__ATRIUM_ENV__';
 
+// A login shell can take several seconds to start behind a heavy rc (compinit
+// auditing, nvm, corporate network calls). Resolution runs off the critical path
+// now, so the cap is generous — better to wait and capture the real env than to
+// time out and fall back to the truncated GUI one.
+const RESOLVE_TIMEOUT_MS = 10_000;
+
+let pending: Promise<void> | null = null;
+
 /**
  * GUI-launched apps on macOS/Linux inherit a truncated environment — none of the
  * variables the user exports from their shell rc (PATH, but also API tokens and
  * config), the classic "works in the terminal, fails from the Dock" gap. Resolve
- * the real login-shell environment once at startup and merge it into process.env,
- * so spawned MCP servers — and the env-var config fields (envPassthrough /
- * headersFromEnv / bearerTokenEnvVar) — see what the terminal does.
+ * the real login-shell environment once and merge it into process.env, so spawned
+ * MCP servers — and the env-var config fields (envPassthrough / headersFromEnv /
+ * bearerTokenEnvVar) — see what the terminal does.
  *
- * PATH is merged (prepend + dedupe) so a misbehaving rc can only add dirs, never
- * drop ours; every other shell var fills in only where we don't already have one,
- * leaving the Electron/Node runtime vars untouched. No-op on Windows (GUI
- * processes inherit the full env there) or when resolution fails.
+ * Async and memoized. The caller kicks this off during boot but MUST NOT block
+ * first paint on it; anything that spawns a subprocess (MCP stdio) awaits the
+ * returned promise so it sees the merged PATH. PATH is merged (prepend + dedupe)
+ * so a misbehaving rc can only add dirs, never drop ours; every other shell var
+ * fills in only where we don't already have one, leaving the Electron/Node
+ * runtime vars untouched. No-op on Windows (GUI processes inherit the full env
+ * there) or when resolution fails.
  */
-export function loadShellEnv(): void {
+export function loadShellEnv(): Promise<void> {
+  pending ??= resolveShellEnv();
+  return pending;
+}
+
+async function resolveShellEnv(): Promise<void> {
   if (process.platform === 'win32') return;
   const shell = process.env.SHELL || '/bin/zsh';
   try {
-    // -ilc loads the login + interactive rc files where users set vars; the
-    // delimiters fence `env`'s output off from any banner/MOTD the rc prints.
-    const out = execFileSync(shell, ['-ilc', `echo -n "${DELIM}"; env; echo -n "${DELIM}"`], {
-      encoding: 'utf8',
-      timeout: 5000,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
-    const body = out.split(DELIM)[1];
+    const body = (await runEnvDump(shell)).split(DELIM)[1];
     if (!body) return;
 
     for (const line of body.split('\n')) {
@@ -45,6 +54,37 @@ export function loadShellEnv(): void {
   } catch (err) {
     log.warn('could not load the login-shell environment; using the inherited one', err);
   }
+}
+
+/**
+ * Run the login + interactive shell and capture `env`. stdin is /dev/null so an
+ * interactive shell can never block reading input; the delimiters fence the env
+ * output off from any banner/MOTD the rc prints. Rejects on spawn failure (e.g.
+ * the shell binary is missing) or when the shell outruns the timeout.
+ */
+function runEnvDump(shell: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(shell, ['-ilc', `echo -n "${DELIM}"; env; echo -n "${DELIM}"`], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    let out = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`login-shell env resolution timed out after ${RESOLVE_TIMEOUT_MS}ms`));
+    }, RESOLVE_TIMEOUT_MS);
+    child.stdout?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => {
+      out += chunk;
+    });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', () => {
+      clearTimeout(timer);
+      resolve(out);
+    });
+  });
 }
 
 /** Prepend the shell PATH onto the inherited one, de-duping, so we never drop dirs. */


### PR DESCRIPTION
## Problem

On a fresh machine the Dock icon appears immediately but the window paints ~6s later. From the logs, the main process blocks first paint on three sequential steps:

- **`loadShellEnv()`** — synchronous, ~5.7s on a machine with a heavy `.zshrc` (compinit auditing, nvm, corporate network calls). Security/EDR software intercepting every file `stat` inflates it further (measured `zsh -ilc exit` = 6.85s wall, 32% CPU → mostly I/O wait).
- **`await refreshSkills()`** — the skill scan, ~0.5s.
- **`await startHttpServer()`** — sequenced after both.

The window is only created *after* all of them.

## Change

Paint the window as soon as the fast required init is done (db, settings, server + IPC — all sub-100ms), and push the slow/spawn-related work off the critical path:

- **`loadShellEnv` is now async** (`spawn`-based, memoized, `stdin=/dev/null` so an interactive shell can't block on input). Timeout raised 5s → 10s since it no longer blocks paint, so a slow-but-valid shell (like the 6.85s one) is now *captured* instead of timing out — the `could not load the login-shell environment` warning goes away too.
- **MCP init is gated on the shell-env promise** (`shellEnvReady.then(() => mcpManager.init(db))`) — stdio servers read `PATH` from `process.env` at spawn, so they must not start before the merge.
- **Skills discovery runs in the background**, and the **scheduler starts once the scan settles** (even if it fails), so a boot-time catch-up run still sees the skill index. This closes the only realistic race from de-blocking the scan (an automated catch-up firing before skills load; interactive turns already outlast the scan).
- **HTTP server moved before window creation** so the IPC handler is attached before the renderer's first tRPC call.

## Result

First paint no longer waits on the login shell or the skill scan — the window appears right after the fast init instead of ~6s in.

## Testing

- `npm run typecheck` ✅
- `biome check` ✅
- Manual: verify window paints promptly on a machine with a slow `.zshrc`; MCP stdio servers still connect; a scheduled catch-up run still has skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)