### PR TITLE
feat(chat): edit and re-run a user message

### DIFF
--- a/src/main/trpc/routers/messages.ts
+++ b/src/main/trpc/routers/messages.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { asc, eq } from 'drizzle-orm';
+import { and, asc, eq, inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { messages, threads } from '../../db/schema';
 import { publicProcedure, router } from '../trpc';
@@ -56,5 +56,24 @@ export const messagesRouter = router({
         .where(eq(threads.id, input.threadId))
         .run();
       return { id };
+    }),
+
+  /**
+   * Delete a set of messages from a thread by id. Used when a user edits an
+   * earlier message and re-runs: the edited message and everything after it are
+   * dropped so the server rebuilds the correct forked history from the DB (the
+   * client sends only the latest message, so the DB is the source of truth).
+   * The id set comes from the client's own ordered message list, so truncation
+   * is exact — no timestamp comparison that could mis-slice same-millisecond
+   * inserts. Scoped to threadId so a stray id can't reach across threads.
+   */
+  deleteMany: publicProcedure
+    .input(z.object({ threadId: z.string(), ids: z.array(z.string()).min(1) }))
+    .mutation(({ ctx, input }) => {
+      const res = ctx.db
+        .delete(messages)
+        .where(and(eq(messages.threadId, input.threadId), inArray(messages.id, input.ids)))
+        .run();
+      return { deleted: res.changes };
     }),
 });

--- a/src/renderer/src/components/chat/ChatThread.tsx
+++ b/src/renderer/src/components/chat/ChatThread.tsx
@@ -42,6 +42,8 @@ type ChatThreadProps = {
   /** `/` commands for the composer (e.g. compact). */
   commands: SlashCommand[];
   onSend: (text: string, attachments: Attachment[]) => void;
+  /** Rewrite a user message and re-run from it, discarding everything after. */
+  onEditMessage: (id: string, text: string) => void;
   /** Approve / trust-always / deny a pending tool call (resumes or aborts it). */
   onApprove: (approvalId: string) => void;
   onAlways: (approvalId: string) => void;
@@ -105,6 +107,7 @@ export function ChatThread({
   approvals,
   commands,
   onSend,
+  onEditMessage,
   onApprove,
   onAlways,
   onDeny,
@@ -122,6 +125,9 @@ export function ChatThread({
   const pendingClarify = pendingClarifyId(messages);
   const clarifyPending = pendingClarify !== null;
   const approvalPending = approvals.length > 0;
+  // The composer is held for all of these; editing a past message re-runs a
+  // turn, so it's gated on the same idle window.
+  const busy = live || compacting || clarifyPending || approvalPending;
   const lastId = messages.at(-1)?.id;
   // The head of this thread's auto-review notice queue; each toast self-dismisses.
   const autoReviewToast = useAutoReviewStore((s) => s.toasts[threadId]?.[0]);
@@ -162,7 +168,13 @@ export function ChatThread({
                 return <CompactionDivider key={msg.id} summary={messageText(msg.parts)} />;
               }
               return msg.role === 'user' ? (
-                <UserMessage key={msg.id} parts={msg.parts} />
+                <UserMessage
+                  key={msg.id}
+                  id={msg.id}
+                  parts={msg.parts}
+                  canEdit={!busy}
+                  onEdit={onEditMessage}
+                />
               ) : (
                 <AssistantMessage
                   key={msg.id}
@@ -219,7 +231,7 @@ export function ChatThread({
             />
           )}
           <Composer
-            disabled={live || compacting || clarifyPending || approvalPending}
+            disabled={busy}
             streaming={live}
             placeholder={
               clarifyPending

--- a/src/renderer/src/components/chat/UserMessage.tsx
+++ b/src/renderer/src/components/chat/UserMessage.tsx
@@ -1,5 +1,5 @@
 import type { AtriumUIMessage } from '@shared/chat';
-import { ChevronDown, FileText, Package } from 'lucide-react';
+import { ChevronDown, FileText, Package, Pencil } from 'lucide-react';
 import { memo, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { openAttachment } from '../../state/attachment-viewer-store';
@@ -26,6 +26,12 @@ const SKILL_USE = /<skill-use>([^<]+)<\/skill-use>/g;
 // the model reads it, but it should never show in the user's bubble.
 const REPLY_LANGUAGE = /\n?<reply-language>[^<]*<\/reply-language>/g;
 
+function autosize(el: HTMLTextAreaElement | null): void {
+  if (!el) return;
+  el.style.height = 'auto';
+  el.style.height = `${el.scrollHeight}px`;
+}
+
 function renderWithMentions(text: string): React.ReactNode {
   const nodes: React.ReactNode[] = [];
   let last = 0;
@@ -46,9 +52,17 @@ function renderWithMentions(text: string): React.ReactNode {
 }
 
 export const UserMessage = memo(function UserMessage({
+  id,
   parts,
+  canEdit = false,
+  onEdit,
 }: {
+  id: string;
   parts: AtriumUIMessage['parts'];
+  /** Whether editing is currently allowed (thread idle, nothing pending). */
+  canEdit?: boolean;
+  /** Rewrite this message and re-run from here; drops later messages. */
+  onEdit?: (id: string, text: string) => void | Promise<void>;
 }): React.JSX.Element {
   const { t } = useTranslation();
   const text = parts
@@ -57,6 +71,24 @@ export const UserMessage = memo(function UserMessage({
     .join('')
     .replace(REPLY_LANGUAGE, '');
   const files = parts.filter((p) => p.type === 'file');
+
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const taRef = useRef<HTMLTextAreaElement>(null);
+  const startEdit = (): void => {
+    setDraft(text);
+    setSubmitting(false);
+    setEditing(true);
+  };
+  const submitEdit = (): void => {
+    if (submitting) return;
+    if (draft.trim().length === 0) return;
+    setSubmitting(true);
+    // On success this bubble is replaced by the re-run (it unmounts); only a
+    // failed truncation lands here, and re-enables the editor for a retry.
+    Promise.resolve(onEdit?.(id, draft)).catch(() => setSubmitting(false));
+  };
 
   const bodyRef = useRef<HTMLDivElement>(null);
   const [collapsed, setCollapsed] = useState(true);
@@ -74,6 +106,17 @@ export const UserMessage = memo(function UserMessage({
     ro.observe(el);
     return () => ro.disconnect();
   }, [collapsed]);
+
+  // Grow the editor to fit the seeded text on open, and focus with the caret
+  // at the end so the user continues where they left off.
+  useLayoutEffect(() => {
+    if (!editing) return;
+    const el = taRef.current;
+    if (!el) return;
+    autosize(el);
+    el.focus();
+    el.setSelectionRange(el.value.length, el.value.length);
+  }, [editing]);
 
   return (
     <div className="group mb-5 flex flex-col items-end gap-1.5">
@@ -118,33 +161,84 @@ export const UserMessage = memo(function UserMessage({
           })}
         </div>
       )}
-      {text.length > 0 && (
-        <div className="max-w-[75%] rounded-2xl bg-user-bubble-bg px-4 py-2.5 text-base text-user-bubble-fg leading-snug">
-          <div
-            ref={bodyRef}
-            className="whitespace-pre-wrap"
-            style={collapsed ? COLLAPSED_STYLE : undefined}
-          >
-            {renderWithMentions(text)}
-          </div>
-          {overflowing && (
+      {editing ? (
+        <div className="w-full rounded-2xl bg-user-bubble-bg px-4 py-3">
+          <textarea
+            ref={taRef}
+            value={draft}
+            onChange={(e) => {
+              setDraft(e.target.value);
+              autosize(e.target);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                setEditing(false);
+              } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                submitEdit();
+              }
+            }}
+            rows={1}
+            className="max-h-[320px] w-full resize-none overflow-y-auto bg-transparent text-base text-user-bubble-fg leading-snug outline-none"
+          />
+          <div className="mt-2 flex justify-end gap-2">
             <button
               type="button"
-              onClick={() => setCollapsed((c) => !c)}
-              className="mt-1.5 flex items-center gap-0.5 text-fg-tertiary text-sm transition-colors hover:text-fg-secondary"
+              onClick={() => setEditing(false)}
+              className="rounded-lg border border-border-default bg-surface px-3 py-1.5 text-fg-secondary text-sm transition-colors hover:bg-elevated"
             >
-              {collapsed ? t('chat.showMore') : t('chat.showLess')}
-              <ChevronDown
-                className={`size-4 transition-transform ${collapsed ? '' : 'rotate-180'}`}
-              />
+              {t('common.cancel')}
             </button>
-          )}
+            <button
+              type="button"
+              onClick={submitEdit}
+              disabled={submitting || draft.trim().length === 0}
+              className="rounded-lg bg-accent px-3 py-1.5 text-fg-on-accent text-sm transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {t('composer.send')}
+            </button>
+          </div>
         </div>
-      )}
-      {text.length > 0 && (
-        <div className="opacity-0 transition-opacity group-hover:opacity-100">
-          <CopyButton text={text} />
-        </div>
+      ) : (
+        text.length > 0 && (
+          <>
+            <div className="max-w-[75%] rounded-2xl bg-user-bubble-bg px-4 py-2.5 text-base text-user-bubble-fg leading-snug">
+              <div
+                ref={bodyRef}
+                className="whitespace-pre-wrap"
+                style={collapsed ? COLLAPSED_STYLE : undefined}
+              >
+                {renderWithMentions(text)}
+              </div>
+              {overflowing && (
+                <button
+                  type="button"
+                  onClick={() => setCollapsed((c) => !c)}
+                  className="mt-1.5 flex items-center gap-0.5 text-fg-tertiary text-sm transition-colors hover:text-fg-secondary"
+                >
+                  {collapsed ? t('chat.showMore') : t('chat.showLess')}
+                  <ChevronDown
+                    className={`size-4 transition-transform ${collapsed ? '' : 'rotate-180'}`}
+                  />
+                </button>
+              )}
+            </div>
+            <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+              <CopyButton text={text} />
+              {canEdit && onEdit && (
+                <button
+                  type="button"
+                  onClick={startEdit}
+                  title={t('common.edit')}
+                  className="rounded p-1 text-fg-tertiary transition-colors hover:bg-elevated hover:text-fg-secondary"
+                >
+                  <Pencil className="size-3.5" />
+                </button>
+              )}
+            </div>
+          </>
+        )
       )}
     </div>
   );

--- a/src/renderer/src/routes/_app/chat/$threadId.tsx
+++ b/src/renderer/src/routes/_app/chat/$threadId.tsx
@@ -209,6 +209,32 @@ function ChatRunner({
     },
     [model, sendMessage],
   );
+
+  // Read the live message list off a ref so onEditMessage stays referentially
+  // stable (it can't depend on `messages`, which changes every stream chunk) —
+  // that keeps UserMessage's memo intact through a streaming turn.
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+  const deleteMessages = trpc.messages.deleteMany.useMutation();
+  const onEditMessage = useCallback(
+    async (messageId: string, text: string): Promise<void> => {
+      if (!model) return;
+      const current = messagesRef.current;
+      const index = current.findIndex((m) => m.id === messageId);
+      if (index === -1) return;
+      // The edited message keeps its attachments; only its text is rewritten.
+      const files = current[index].parts.filter((p) => p.type === 'file');
+      const removeIds = current.slice(index).map((m) => m.id);
+      // Truncate the DB tail before re-sending: the server rebuilds history from
+      // the DB (the client sends only the latest message), so the edited message
+      // and everything after it must be gone first, or the re-run would replay
+      // the stale branch.
+      await deleteMessages.mutateAsync({ threadId, ids: removeIds });
+      setMessages((prev) => prev.slice(0, index));
+      sendMessage({ text, ...(files.length > 0 && { files }) });
+    },
+    [model, threadId, deleteMessages, setMessages, sendMessage],
+  );
   const onClarify = useCallback(
     (toolCallId: string, result: ClarifyResult) =>
       addToolOutput({ tool: 'ask_clarification', toolCallId, output: result }),
@@ -227,6 +253,7 @@ function ChatRunner({
       approvals={approvals}
       commands={commands}
       onSend={onSend}
+      onEditMessage={onEditMessage}
       onApprove={onApprove}
       onAlways={onAlways}
       onDeny={onDeny}


### PR DESCRIPTION
## What

Adds the ability to edit a previously-sent user message and re-run from it (ChatGPT/Claude-style fork). A pencil affordance on each user message swaps the bubble for an inline editor (**Cancel** / **Send**); sending discards that message and everything after it, then re-sends the rewritten text as a fresh turn.

## How

- **`messages.deleteMany({ threadId, ids })`** — truncation primitive. The client sends only the latest message and the server rebuilds history from the DB, so the edited message + everything after it must be dropped there first. Ids come from the client's ordered list → exact, thread-scoped truncation (no timestamp-tie risk).
- **`onEditMessage`** (in `ChatRunner`) — truncate DB tail → `setMessages` slice → `sendMessage`. Kept referentially stable via a `messagesRef` so `UserMessage`'s `memo` survives streaming.
- **`UserMessage`** — inline auto-growing editor. Original **attachments are preserved**; Esc cancels, ⌘/Ctrl+Enter sends.
- Editing is gated to the idle window (no in-flight turn / clarification / approval), reusing the composer's `busy` flag.

## Verification

Verified end-to-end in an isolated Electron instance (DB copy, separate user-data-dir) against the live renderer — the real app/DB untouched. Editing a mid-conversation message with an image attachment: the DB tail was truncated correctly (edited message + all 3 after it deleted, earlier pair kept), a new user message was appended with the **image + new text preserved**, the re-run fired and reached the model, and the UI forked correctly with the thread re-sorted in the sidebar. Cancel restores the bubble. `typecheck` + `biome` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)