### PR TITLE
feat(updater): background auto-download, hourly polling, and the About page

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -139,11 +139,10 @@ app.whenReady().then(async () => {
   });
 
   // Broadcast updater state into whichever main window is live (it survives
-  // hide/close, and getWindow() re-resolves after a rebuild). Then run a single
-  // startup check off the critical path — v1 has no polling, and the delay keeps
-  // the network probe from competing with first paint.
+  // hide/close, and getWindow() re-resolves after a rebuild). Then start the
+  // post-launch check + periodic poll off the critical path.
   updaterManager.init(() => mainWindow);
-  setTimeout(() => void updaterManager.check(), 4000);
+  updaterManager.startAutoCheck();
 
   // Resolve the user's login-shell environment in the background so PATH and
   // their exported vars match the terminal. It can take seconds behind a slow
@@ -251,5 +250,6 @@ app.on('before-quit', () => {
   serverEndpoint?.dispose();
   scheduledManager.dispose();
   void mcpManager.dispose();
+  updaterManager.dispose();
   closeDb();
 });

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -10,14 +10,19 @@ import { createLogger } from './log';
 
 const log = createLogger('updater');
 
+/** Delay the first check so it doesn't compete with first paint / startup IO. */
+const STARTUP_CHECK_DELAY = 4_000;
+/** Re-check on a slow cadence so a long-running window still notices releases. */
+const POLL_INTERVAL = 60 * 60_000;
+
 /**
  * Wraps electron-updater in a small state machine and broadcasts every
  * transition to the renderer over a single channel, so any window (including one
  * reopened after a hide/close) re-seeds from getState() and then follows live.
  *
- * v1 is deliberately click-to-download: autoDownload is off and nothing is
- * fetched until the renderer calls download(). Background download and periodic
- * polling are intentionally deferred until the update path is proven stable.
+ * A found update always downloads in the background (autoUpdater.autoDownload),
+ * so opening the dialog lands on live progress or "ready to install". Checks run
+ * shortly after launch and then on a fixed interval.
  */
 class UpdaterManager {
   private state: UpdaterState = {
@@ -26,8 +31,10 @@ class UpdaterManager {
     info: null,
     progress: null,
     error: null,
+    lastCheckedAt: null,
   };
   private getWindow: () => BrowserWindow | null = () => null;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
   private wired = false;
 
   init(getWindow: () => BrowserWindow | null): void {
@@ -36,14 +43,26 @@ class UpdaterManager {
     this.wired = true;
 
     autoUpdater.logger = log;
-    autoUpdater.autoDownload = false;
+    // Download a found update in the background so the dialog opens on progress
+    // or "ready to install". autoInstallOnAppQuit stays off so the swap only
+    // happens on an explicit Restart Now, never silently on quit.
+    autoUpdater.autoDownload = true;
     autoUpdater.autoInstallOnAppQuit = false;
     autoUpdater.allowDowngrade = false;
 
     autoUpdater.on('checking-for-update', () => this.set({ stage: 'checking', error: null }));
-    autoUpdater.on('update-available', (info) =>
-      this.set({ stage: 'available', info: toInfo(info), progress: null }),
-    );
+    autoUpdater.on('update-available', (info) => {
+      const next = toInfo(info);
+      // A poll can re-announce a version we're already fetching or have staged;
+      // ignore it so the UI doesn't reset and a second download isn't kicked.
+      const busyWithSame =
+        (this.state.stage === 'downloading' || this.state.stage === 'downloaded') &&
+        this.state.info?.version === next.version;
+      if (busyWithSame) return;
+      // electron-updater auto-downloads from here (autoDownload); the ensuing
+      // download-progress / update-downloaded events drive the rest.
+      this.set({ stage: 'available', info: next, progress: null });
+    });
     autoUpdater.on('update-not-available', () =>
       this.set({ stage: 'idle', info: null, progress: null }),
     );
@@ -58,14 +77,28 @@ class UpdaterManager {
     );
   }
 
+  /** Check shortly after launch, then poll on a fixed interval. */
+  startAutoCheck(): void {
+    setTimeout(() => void this.check(), STARTUP_CHECK_DELAY);
+    this.pollTimer ??= setInterval(() => void this.check(), POLL_INTERVAL);
+  }
+
+  dispose(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+
   /** One-shot check. Silent no-op when unpacked unless FORCE_DEV_UPDATE_CONFIG. */
   async check(): Promise<void> {
     if (!this.canCheck()) return;
     try {
       await autoUpdater.checkForUpdates();
+      this.set({ lastCheckedAt: Date.now() });
     } catch (err) {
       log.warn('checkForUpdates failed:', err);
-      this.set({ stage: 'error', error: errorMessage(err) });
+      this.set({ stage: 'error', error: errorMessage(err), lastCheckedAt: Date.now() });
     }
   }
 

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -391,6 +391,22 @@ export const en: typeof zh = {
       systemDesc: 'Follow the system',
       note: 'Changes apply immediately. System mode follows the macOS appearance preference.',
     },
+    about: {
+      description:
+        'Atrium is a local-first desktop AI agent. Bring your own API key to connect any model provider, with the agent capabilities common in tools today.',
+      craftedBy: 'Crafted by <author>lhz960904</author>',
+      lastChecked: 'Last checked',
+      never: 'Never',
+      checkNow: 'Check for updates',
+      checking: 'Checking…',
+      upToDate: "You're already on the latest version.",
+      available: 'Version {{version}} available',
+      downloadingStatus: 'Downloading… {{percent}}%',
+      readyStatus: 'Version {{version}} downloaded, ready to install',
+      checkFailed: 'Update check failed',
+      feedback: 'Send Feedback',
+      feedbackDesc: 'Report a bug or request a feature on GitHub.',
+    },
     language: {
       title: 'Language',
       zh: '中文',

--- a/src/renderer/src/i18n/zh.ts
+++ b/src/renderer/src/i18n/zh.ts
@@ -391,6 +391,22 @@ export const zh = {
       systemDesc: '跟随系统外观',
       note: '切换会立即生效。System 模式会跟随 macOS 外观偏好自动变换。',
     },
+    about: {
+      description:
+        'Atrium 是一款本地优先的桌面 AI Agent 助手。支持携带密钥接入任意模型提供商，涵盖目前市面常见的 AI Agent 功能。',
+      craftedBy: '由 <author>lhz960904</author> 打造',
+      lastChecked: '上次检查',
+      never: '从未',
+      checkNow: '检查更新',
+      checking: '检查中…',
+      upToDate: '已是最新版本。',
+      available: '发现新版本 {{version}}',
+      downloadingStatus: '下载中 {{percent}}%',
+      readyStatus: '{{version}} 已下载，可安装',
+      checkFailed: '检查更新失败',
+      feedback: '发送反馈',
+      feedbackDesc: '在 GitHub 上反馈问题或提出新功能。',
+    },
     language: {
       title: '语言',
       zh: '中文',

--- a/src/renderer/src/routes/settings/$section.tsx
+++ b/src/renderer/src/routes/settings/$section.tsx
@@ -1,8 +1,9 @@
 import type { ComposerSendKey } from '@shared/settings';
+import type { UpdaterStage } from '@shared/update';
 import { createFileRoute, notFound } from '@tanstack/react-router';
 import type { ParseKeys } from 'i18next';
-import { Check, Monitor, Moon, Sun } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
+import { ArrowUpRight, Check, MessageSquare, Monitor, Moon, Sun } from 'lucide-react';
+import { Trans, useTranslation } from 'react-i18next';
 import { Select } from '../../components/Select';
 import { ArchivedSection } from '../../components/settings/archived/ArchivedSection';
 import { IdentitySection } from '../../components/settings/identity/IdentitySection';
@@ -19,6 +20,7 @@ import { trpc } from '../../lib/trpc';
 import { type LanguagePref, useLanguage } from '../../lib/use-language';
 import { useSetting } from '../../lib/use-setting';
 import { type Theme, useThemeStore } from '../../state/theme-store';
+import { useUpdateStore } from '../../state/update-store';
 
 export const Route = createFileRoute('/settings/$section')({
   component: SectionView,
@@ -65,7 +67,7 @@ const SECTIONS: Record<string, SectionMeta> = {
   connections: { titleKey: 'settings.sections.connectionsTitle', Component: PlaceholderSection },
   worktrees: { titleKey: 'settings.sections.worktreesTitle', Component: PlaceholderSection },
   archived: { titleKey: 'settings.sections.archivedTitle', Component: ArchivedSection },
-  about: { titleKey: 'settings.sections.aboutTitle', Component: PlaceholderSection },
+  about: { titleKey: 'settings.sections.aboutTitle', Component: AboutSection },
 };
 
 function SectionView(): React.JSX.Element {
@@ -274,6 +276,146 @@ function AppearanceSection(): React.JSX.Element {
       </div>
       <p className="mt-4 text-fg-tertiary text-xs">{t('settings.appearance.note')}</p>
     </section>
+  );
+}
+
+const AUTHOR_URL = 'https://github.com/lhz960904';
+const ISSUES_URL = 'https://github.com/lhz960904/atrium/issues/new';
+
+/** Semantic colour for the update-status dot. */
+const STATUS_DOT: Record<UpdaterStage, string> = {
+  idle: 'bg-success',
+  checking: 'bg-accent-alt',
+  available: 'bg-accent',
+  downloading: 'bg-accent',
+  downloaded: 'bg-accent',
+  error: 'bg-danger',
+};
+
+/** Locale-aware "3 minutes ago" for the last-checked line; `never` when unset. */
+function formatChecked(ts: number | null, lang: string, never: string): string {
+  if (!ts) return never;
+  const rtf = new Intl.RelativeTimeFormat(lang, { numeric: 'auto' });
+  const sec = Math.round((ts - Date.now()) / 1000);
+  const abs = Math.abs(sec);
+  if (abs < 60) return rtf.format(sec, 'second');
+  if (abs < 3600) return rtf.format(Math.round(sec / 60), 'minute');
+  if (abs < 86_400) return rtf.format(Math.round(sec / 3600), 'hour');
+  return rtf.format(Math.round(sec / 86_400), 'day');
+}
+
+function AboutSection(): React.JSX.Element {
+  const { t, i18n } = useTranslation();
+  const state = useUpdateStore((s) => s.state);
+  const openDialog = useUpdateStore((s) => s.openDialog);
+  const check = trpc.update.check.useMutation();
+
+  const hasUpdate =
+    state.stage === 'available' || state.stage === 'downloading' || state.stage === 'downloaded';
+  const checking = state.stage === 'checking';
+
+  const status = ((): string => {
+    switch (state.stage) {
+      case 'checking':
+        return t('settings.about.checking');
+      case 'available':
+        return t('settings.about.available', { version: state.info?.version ?? '' });
+      case 'downloading':
+        return t('settings.about.downloadingStatus', {
+          percent: Math.round(state.progress?.percent ?? 0),
+        });
+      case 'downloaded':
+        return t('settings.about.readyStatus', { version: state.info?.version ?? '' });
+      case 'error':
+        return t('settings.about.checkFailed');
+      default:
+        return t('settings.about.upToDate');
+    }
+  })();
+
+  const lastChecked = formatChecked(state.lastCheckedAt, i18n.language, t('settings.about.never'));
+
+  const updateBtn =
+    'shrink-0 rounded-lg bg-accent px-3.5 py-2 font-medium text-fg-on-accent text-sm shadow-xs hover:bg-accent-hover disabled:opacity-60';
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Product panel: identity up top, a divided update band below. */}
+      <div className="overflow-hidden rounded-2xl border border-border-default bg-surface shadow-xs">
+        <div className="px-7 pt-7 pb-6">
+          <div className="flex items-center gap-2.5">
+            <h1 className="font-semibold text-fg-primary text-lg tracking-tight">Atrium</h1>
+            <span className="rounded-full bg-accent-soft px-2 py-0.5 font-medium text-accent text-xs tabular-nums">
+              {state.currentVersion}
+            </span>
+          </div>
+          <p className="mt-2 text-fg-secondary text-sm leading-relaxed">
+            {t('settings.about.description')}
+          </p>
+          <p className="mt-2 text-fg-tertiary text-xs">
+            <Trans
+              i18nKey="settings.about.craftedBy"
+              components={{
+                author: (
+                  // biome-ignore lint/a11y/useAnchorContent: Trans injects the link text
+                  <a
+                    href={AUTHOR_URL}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="font-medium text-accent hover:underline"
+                  />
+                ),
+              }}
+            />
+          </p>
+        </div>
+
+        <div className="flex items-center justify-between gap-4 border-border-default border-t px-7 py-4">
+          <div className="flex min-w-0 items-start gap-2.5">
+            <span
+              className={`mt-1.5 size-2 shrink-0 rounded-full ${STATUS_DOT[state.stage]} ${checking ? 'animate-pulse' : ''}`}
+            />
+            <div className="min-w-0">
+              <div className="text-fg-primary text-sm">{status}</div>
+              <div className="mt-0.5 text-fg-tertiary text-xs">
+                {t('settings.about.lastChecked')} · {lastChecked}
+              </div>
+            </div>
+          </div>
+          {hasUpdate ? (
+            <button type="button" onClick={openDialog} className={updateBtn}>
+              {t('update.entry')}
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => check.mutate()}
+              disabled={checking}
+              className={updateBtn}
+            >
+              {checking ? t('settings.about.checking') : t('settings.about.checkNow')}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Feedback: the whole card opens GitHub issues. */}
+      <a
+        href={ISSUES_URL}
+        target="_blank"
+        rel="noreferrer"
+        className="group flex items-center gap-3.5 rounded-2xl border border-border-default bg-surface px-5 py-4 shadow-xs transition-colors hover:border-border-strong"
+      >
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-accent-soft text-accent">
+          <MessageSquare className="size-[18px]" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="font-medium text-fg-primary text-sm">{t('settings.about.feedback')}</div>
+          <div className="mt-0.5 text-fg-tertiary text-xs">{t('settings.about.feedbackDesc')}</div>
+        </div>
+        <ArrowUpRight className="size-4 shrink-0 text-fg-tertiary transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-fg-secondary" />
+      </a>
+    </div>
   );
 }
 

--- a/src/renderer/src/state/update-store.ts
+++ b/src/renderer/src/state/update-store.ts
@@ -14,6 +14,7 @@ const INITIAL: UpdaterState = {
   info: null,
   progress: null,
   error: null,
+  lastCheckedAt: null,
 };
 
 type UpdateStore = {

--- a/src/shared/update.ts
+++ b/src/shared/update.ts
@@ -35,4 +35,6 @@ export type UpdaterState = {
   info: UpdateAvailableInfo | null;
   progress: UpdateProgress | null;
   error: string | null;
+  /** Epoch ms of the last completed check (success or failure); null = never. */
+  lastCheckedAt: number | null;
 };


### PR DESCRIPTION
v2 of the in-app updater (v1 shipped in 0.3.0, #28). Builds on the merged v1.

## What's new
- **Always auto-download** — electron-updater's `autoDownload` is on, so a found update fetches in the background and the dialog/entry lands on "ready to install" (one-click Restart). No user setting; `autoInstallOnAppQuit` stays off so nothing installs silently.
- **Polling** — a post-launch check plus an **hourly** poll (disposed on quit), with a same-version guard so a re-poll doesn't reset the UI or re-download.
- **Last checked** — new `lastCheckedAt` on the updater state, stamped on every completed check.
- **Settings → About** — the placeholder is replaced with a real About page: product panel (name + version pill + description + clickable author byline), a divided status band (semantic status dot, update status, relative last-checked, and a check-for-updates / update button), and a **Send Feedback** card that opens GitHub issues.

## Commits
- `feat(updater): always auto-download and poll hourly`
- `feat(settings): redesign the About page with update status and feedback`

## Verification
- typecheck + biome lint + build all green
- About page rendered with the app's real design tokens (light + dark, across update states) to confirm layout before committing

🤖 Generated with [Claude Code](https://claude.com/claude-code)