### PR TITLE
fix(updater): relaunch on install + clean release-notes rendering

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -139,9 +139,16 @@ app.whenReady().then(async () => {
   });
 
   // Broadcast updater state into whichever main window is live (it survives
-  // hide/close, and getWindow() re-resolves after a rebuild). Then start the
-  // post-launch check + periodic poll off the critical path.
-  updaterManager.init(() => mainWindow);
+  // hide/close, and getWindow() re-resolves after a rebuild). onBeforeInstall
+  // flips isQuitting so the hide-on-close handler lets the window close during
+  // the update relaunch instead of hiding it. Then start the post-launch check +
+  // periodic poll off the critical path.
+  updaterManager.init({
+    getWindow: () => mainWindow,
+    onBeforeInstall: () => {
+      isQuitting = true;
+    },
+  });
   updaterManager.startAutoCheck();
 
   // Resolve the user's login-shell environment in the background so PATH and

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -34,11 +34,18 @@ class UpdaterManager {
     lastCheckedAt: null,
   };
   private getWindow: () => BrowserWindow | null = () => null;
+  private onBeforeInstall: () => void = () => {};
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private wired = false;
 
-  init(getWindow: () => BrowserWindow | null): void {
-    this.getWindow = getWindow;
+  init(opts: {
+    getWindow: () => BrowserWindow | null;
+    /** Called right before quitAndInstall so the app stops intercepting the
+     *  window close — otherwise the hide-on-close handler blocks the relaunch. */
+    onBeforeInstall: () => void;
+  }): void {
+    this.getWindow = opts.getWindow;
+    this.onBeforeInstall = opts.onBeforeInstall;
     if (this.wired) return;
     this.wired = true;
 
@@ -116,6 +123,10 @@ class UpdaterManager {
   /** Quit and swap in the downloaded update; only valid after 'downloaded'. */
   install(): void {
     if (this.state.stage !== 'downloaded') return;
+    // quitAndInstall closes every window before it quits+relaunches; let the app
+    // know so its hide-on-close handler doesn't preventDefault and stall Squirrel
+    // (which then reports "The command is disabled and cannot be executed").
+    this.onBeforeInstall();
     // isSilent=false so the OS installer UI can surface any prompt; isForceRunAfter
     // relaunches straight into the new version instead of leaving the app closed.
     autoUpdater.quitAndInstall(false, true);

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -1,5 +1,6 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { ArrowRight, CheckCircle2, Download, Loader2, RotateCw } from 'lucide-react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { trpc } from '../lib/trpc';
 import { useUpdateStore } from '../state/update-store';
@@ -12,6 +13,74 @@ function fmtEta(seconds: number): string {
   const s = Math.round(seconds);
   if (s < 60) return `${s}s`;
   return `${Math.floor(s / 60)}m ${s % 60}s`;
+}
+
+/** Drop release-please's trailing "(#30) (faeb8e2)" PR/commit refs — noise here. */
+function cleanItem(text: string): string {
+  return text
+    .replace(/\s*\(#\d+\)/g, '')
+    .replace(/\s*\([0-9a-f]{7,40}\)/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * electron-updater's GitHub provider returns release notes as HTML (from the
+ * releases atom feed), so parse it into clean, structured content rather than
+ * dumping raw tags: drop the redundant version header (the dialog already shows
+ * the version compare), keep section headings, and turn the change list into
+ * plain bullets without the PR/commit link noise. Falls back to plain text.
+ */
+function buildReleaseNotes(html: string): React.JSX.Element | null {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const blocks: React.JSX.Element[] = [];
+  let key = 0;
+
+  for (const el of Array.from(doc.body.children)) {
+    const tag = el.tagName.toLowerCase();
+    if (tag === 'h1' || tag === 'h2') continue; // version header — redundant
+    if (tag === 'h3' || tag === 'h4') {
+      const text = el.textContent?.trim();
+      if (text)
+        blocks.push(
+          <div
+            key={key++}
+            className="font-medium text-[11px] text-fg-tertiary uppercase tracking-wide"
+          >
+            {text}
+          </div>,
+        );
+    } else if (tag === 'ul' || tag === 'ol') {
+      const items = Array.from(el.querySelectorAll('li'))
+        .map((li) => cleanItem(li.textContent ?? ''))
+        .filter(Boolean);
+      if (items.length)
+        blocks.push(
+          <ul key={key++} className="flex flex-col gap-1">
+            {items.map((it) => (
+              <li key={it} className="flex gap-2">
+                <span className="text-fg-disabled">•</span>
+                <span>{it}</span>
+              </li>
+            ))}
+          </ul>,
+        );
+    } else {
+      const text = el.textContent?.trim();
+      if (text) blocks.push(<p key={key++}>{text}</p>);
+    }
+  }
+
+  if (blocks.length === 0) {
+    // Plain-text notes (no block markup).
+    const text = doc.body.textContent?.trim();
+    return text ? <div className="whitespace-pre-wrap">{text}</div> : null;
+  }
+  return <div className="flex flex-col gap-2.5">{blocks}</div>;
+}
+
+function ReleaseNotes({ html }: { html: string }): React.JSX.Element | null {
+  return useMemo(() => buildReleaseNotes(html), [html]);
 }
 
 /**
@@ -60,8 +129,8 @@ export function UpdateDialog(): React.JSX.Element {
                 <span className="font-medium text-fg-tertiary text-xs uppercase tracking-wide">
                   {t('update.whatsNew')}
                 </span>
-                <div className="max-h-32 overflow-y-auto whitespace-pre-wrap text-fg-secondary text-sm leading-relaxed">
-                  {info.releaseNotes}
+                <div className="max-h-40 overflow-y-auto text-fg-secondary text-sm leading-relaxed">
+                  <ReleaseNotes html={info.releaseNotes} />
                 </div>
               </div>
             )}

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -95,6 +95,7 @@ export function UpdateDialog(): React.JSX.Element {
   const state = useUpdateStore((s) => s.state);
   const dialogOpen = useUpdateStore((s) => s.dialogOpen);
   const closeDialog = useUpdateStore((s) => s.closeDialog);
+  const check = trpc.update.check.useMutation();
   const download = trpc.update.download.useMutation();
   const install = trpc.update.install.useMutation();
 
@@ -200,7 +201,7 @@ export function UpdateDialog(): React.JSX.Element {
                 <button type="button" className={ghostBtn} onClick={closeDialog}>
                   {t('common.close')}
                 </button>
-                <button type="button" className={accentBtn} onClick={() => download.mutate()}>
+                <button type="button" className={accentBtn} onClick={() => check.mutate()}>
                   {t('update.retry')}
                 </button>
               </>


### PR DESCRIPTION
Two updater fixes found while testing the 0.3.0 → 0.4.0 auto-update end to end.

## 1. Relaunch on install (`fix(updater): let the window close so the update can relaunch`)
Clicking **Restart Now** failed with `The command is disabled and cannot be executed`.

`quitAndInstall` closes every window before it quits and relaunches. On macOS the hide-on-close handler calls `event.preventDefault()` (to hide instead of close) while `isQuitting` is false — so the window only hides and Squirrel's relaunch never completes. Fix: an `onBeforeInstall` hook flips `isQuitting` right before `quitAndInstall`, so the window actually closes. The error-state **Retry** now re-checks (re-detect + re-download) instead of blindly re-downloading.

## 2. Clean release notes (`fix(updater): render release notes as clean text, not raw HTML`)
The "What's new" box showed raw `<h2>/<ul>/<li>` tags. electron-updater's GitHub provider returns release notes as HTML (atom feed). Parse it into clean content: drop the redundant version header, keep section headings, plain bullets without PR/commit link noise. Plain-text notes still render as-is.

## Verification
- typecheck + biome lint + build green; electron-updater still bundles cleanly
- release-notes rendering verified with the real release-please HTML (light + dark)
- ⚠️ the relaunch fix ships *in* the running app, so it can only be fully verified once a build carrying it is released and updated *from* (same two-release pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)