### PR TITLE
fix(scheduled): sidebar clock badge + running-run spinner and absolute run time

### DIFF
--- a/src/renderer/src/components/scheduled/TaskDetail.tsx
+++ b/src/renderer/src/components/scheduled/TaskDetail.tsx
@@ -1,10 +1,19 @@
 import { useNavigate } from '@tanstack/react-router';
-import { CheckCircle2, MessageSquareText, Pause, Play, Trash2, X, XCircle } from 'lucide-react';
+import {
+  CheckCircle2,
+  LoaderCircle,
+  MessageSquareText,
+  Pause,
+  Play,
+  Trash2,
+  X,
+  XCircle,
+} from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Select } from '../../components/Select';
 import type { ScheduledRun, ScheduledTask } from '../../lib/schedule-format';
-import { formatDateTime, timeAgo } from '../../lib/time';
+import { formatDateTime } from '../../lib/time';
 import { trpc } from '../../lib/trpc';
 import { deriveGroups } from '../../lib/use-chat-model';
 import { toast } from '../../state/toast-store';
@@ -22,22 +31,26 @@ function Row({ label, children }: { label: string; children: React.ReactNode }):
   );
 }
 
+// A run in progress spins; the rest are terminal outcomes with a static glyph.
+const RUN_STATUS = {
+  running: { Icon: LoaderCircle, color: 'text-accent', spin: true },
+  ok: { Icon: CheckCircle2, color: 'text-success', spin: false },
+  error: { Icon: XCircle, color: 'text-danger', spin: false },
+  skipped: { Icon: Play, color: 'text-fg-tertiary', spin: false },
+} as const;
+
 function RunRow({
   run,
   title,
+  lang,
   onOpen,
 }: {
   run: ScheduledRun;
   title: string;
+  lang: 'en' | 'zh';
   onOpen: (() => void) | undefined;
 }): React.JSX.Element {
-  const Icon = run.status === 'error' ? XCircle : run.status === 'ok' ? CheckCircle2 : Play;
-  const color =
-    run.status === 'error'
-      ? 'text-danger'
-      : run.status === 'ok'
-        ? 'text-success'
-        : 'text-fg-tertiary';
+  const { Icon, color, spin } = RUN_STATUS[run.status];
   return (
     <button
       type="button"
@@ -46,11 +59,13 @@ function RunRow({
       title={run.error ?? undefined}
       className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left enabled:hover:bg-elevated disabled:cursor-default"
     >
-      <Icon className={`size-4 shrink-0 ${color}`} />
+      <Icon className={`size-4 shrink-0 ${color} ${spin ? 'animate-spin' : ''}`} />
       <span className="min-w-0 flex-1 truncate text-fg-secondary text-sm">
         {run.status === 'error' && run.error ? run.error : title}
       </span>
-      <span className="shrink-0 text-fg-disabled text-xs">{timeAgo(run.startedAt)}</span>
+      <span className="shrink-0 text-fg-disabled text-xs">
+        {formatDateTime(run.startedAt, lang)}
+      </span>
     </button>
   );
 }
@@ -75,7 +90,12 @@ export function TaskDetail({
   const { t } = useTranslation();
   const navigate = useNavigate();
   const utils = trpc.useUtils();
-  const runs = trpc.scheduled.runs.useQuery({ id: task.id });
+  // While a run is in flight its row shows a spinner; poll so it flips to the
+  // terminal ok/error glyph on finish (a background firing won't invalidate this).
+  const runs = trpc.scheduled.runs.useQuery(
+    { id: task.id },
+    { refetchInterval: (data) => (data?.some((r) => r.status === 'running') ? 2000 : false) },
+  );
   const projects = trpc.projects.list.useQuery();
   const providers = trpc.providers.list.useQuery();
 
@@ -254,7 +274,7 @@ export function TaskDetail({
           {runs.data && runs.data.length > 0 ? (
             <div className="flex flex-col">
               {runs.data.map((run) => (
-                <RunRow key={run.id} run={run} title={task.title} onOpen={openThread} />
+                <RunRow key={run.id} run={run} title={task.title} lang={lang} onOpen={openThread} />
               ))}
             </div>
           ) : (

--- a/src/renderer/src/components/sidebar/Sidebar.tsx
+++ b/src/renderer/src/components/sidebar/Sidebar.tsx
@@ -28,6 +28,12 @@ export const Sidebar = memo(function Sidebar(): React.JSX.Element {
   // the interval is cheap (unlike polling message content).
   const { data: running } = trpc.threads.running.useQuery(undefined, { refetchInterval: 2000 });
   const runningSet = new Set(running);
+  // Threads bound to a scheduled task get a hover clock badge. The binding lives
+  // on the task (scheduledTasks.threadId), so derive the set from the task list.
+  const { data: scheduled } = trpc.scheduled.list.useQuery();
+  const scheduledThreadIds = new Set(
+    (scheduled ?? []).map((task) => task.threadId).filter(Boolean),
+  );
 
   // Adding a project is a sidebar-level action (the Projects header button), not
   // tied to any one row, so it lives here; per-project actions live in ProjectMenu.
@@ -87,7 +93,12 @@ export const Sidebar = memo(function Sidebar(): React.JSX.Element {
   const hasPinned = pinnedThreads.length > 0 || pinnedProjects.length > 0;
 
   const renderThread = (thread: ThreadItem): React.JSX.Element => (
-    <ThreadRow key={thread.id} thread={thread} running={runningSet.has(thread.id)} />
+    <ThreadRow
+      key={thread.id}
+      thread={thread}
+      running={runningSet.has(thread.id)}
+      hasSchedule={scheduledThreadIds.has(thread.id)}
+    />
   );
   const renderProject = (project: ProjectItem): React.JSX.Element => (
     <ProjectRow

--- a/src/renderer/src/components/sidebar/ThreadRow.tsx
+++ b/src/renderer/src/components/sidebar/ThreadRow.tsx
@@ -1,9 +1,10 @@
 import { Link } from '@tanstack/react-router';
-import { Archive, Pin, PinOff } from 'lucide-react';
+import { Archive, Clock, Pin, PinOff } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { timeAgo } from '../../lib/time';
 import { trpc } from '../../lib/trpc';
 import { toast } from '../../state/toast-store';
+import { Tooltip } from '../Tooltip';
 import { RowAction } from './primitives';
 import type { ThreadItem } from './types';
 
@@ -15,9 +16,11 @@ const chatRowActive =
 export function ThreadRow({
   thread,
   running,
+  hasSchedule,
 }: {
   thread: ThreadItem;
   running: boolean;
+  hasSchedule: boolean;
 }): React.JSX.Element {
   const { t } = useTranslation();
   const utils = trpc.useUtils();
@@ -66,6 +69,13 @@ export function ThreadRow({
             )}
           </span>
           <span className="absolute right-0 hidden items-center gap-0.5 group-hover:flex">
+            {hasSchedule && (
+              <Tooltip content={t('sidebar.scheduled')}>
+                <span className="flex items-center p-0.5 text-fg-tertiary">
+                  <Clock className="size-[13px]" />
+                </span>
+              </Tooltip>
+            )}
             <RowAction
               title={thread.pinned ? t('sidebar.unpin') : t('sidebar.pin')}
               icon={

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -37,6 +37,7 @@ export const en: typeof zh = {
   sidebar: {
     running: 'Running',
     unread: 'Unread',
+    scheduled: 'Has a scheduled task',
     search: 'Search',
     pinned: 'Pinned',
     chats: 'Chats',

--- a/src/renderer/src/i18n/zh.ts
+++ b/src/renderer/src/i18n/zh.ts
@@ -38,6 +38,7 @@ export const zh = {
   sidebar: {
     running: '运行中',
     unread: '未读',
+    scheduled: '已绑定定时任务',
     search: '搜索',
     pinned: '置顶',
     chats: '对话',


### PR DESCRIPTION
Two small patch-level fixes around scheduled tasks. Targets the **0.4.2** patch release (both commits are `fix`, so release-please bumps `0.4.1 → 0.4.2` — no minor).

## Changes

**`fix(sidebar)` — clock badge for scheduled-bound threads**
- On row hover, threads bound to a scheduled task now reveal a `Clock` icon in the hover actions (alongside pin / archive), with a tooltip.
- The binding is derived from `scheduled.list` (`scheduledTasks.threadId`) into a set, passed to each `ThreadRow` as `hasSchedule`.

**`fix(scheduled)` — previous-runs list**
- A run still executing (`status === 'running'`) now renders a spinning `LoaderCircle` instead of the misleading static play glyph.
- The runs query polls (2s) while any run is in flight so the spinner settles to the terminal ✓/✗ on finish (a background firing wouldn't otherwise invalidate it).
- The relative "3d" label is replaced with the absolute, localized run time (`formatDateTime`), matching the panel's other timestamps.

## Verification
- `typecheck:web` and `biome check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)