### PR TITLE
fix(scheduled): settle runs orphaned at running on startup

### DIFF
--- a/src/main/agent/scheduled/manager.test.ts
+++ b/src/main/agent/scheduled/manager.test.ts
@@ -125,6 +125,33 @@ test('runNow records a run; last-run + status derive from it', async () => {
   expect(after.lastRunAt).toBeInstanceOf(Date);
 });
 
+test('start() settles a run orphaned at running by a prior session', async () => {
+  const { mgr, db } = setup();
+  const task = mgr.create({ ...RECURRING });
+  // A prior session inserted 'running' then died before the terminal write; the
+  // later 'ok' proves reconcile only touches the orphan, not a finished run.
+  db.insert(schema.scheduledTaskRuns)
+    .values([
+      { id: 'orphan', taskId: task.id, status: 'running', startedAt: new Date(START - 2000) },
+      {
+        id: 'done',
+        taskId: task.id,
+        status: 'ok',
+        startedAt: new Date(START - 1000),
+        finishedAt: new Date(START - 900),
+      },
+    ])
+    .run();
+
+  await mgr.start();
+
+  const runs = mgr.listRuns(task.id);
+  const orphan = runs.find((r) => r.id === 'orphan');
+  expect(orphan?.status).toBe('interrupted');
+  expect(orphan?.finishedAt).toBeInstanceOf(Date);
+  expect(runs.find((r) => r.id === 'done')?.status).toBe('ok');
+});
+
 test('does not stack a second run while one is already in progress', async () => {
   let calls = 0;
   const { mgr } = setup(async () => {

--- a/src/main/agent/scheduled/manager.ts
+++ b/src/main/agent/scheduled/manager.ts
@@ -193,10 +193,31 @@ export class ScheduledTaskManager {
 
   // ── lifecycle ───────────────────────────────────────────────────────────
 
+  /**
+   * A run still marked 'running' at startup is an orphan: the in-flight state
+   * lives only in memory (the `firing` set + resumable's running threads), so
+   * nothing survived the restart to finish it — fire()'s terminal write never
+   * ran because the process died mid-run (quit, crash, or kill). Settle them so
+   * the detail panel stops spinning (and polling) on a run that will never
+   * complete. Boot-only, so a genuinely live run is never caught here.
+   */
+  private reconcileOrphanedRuns(): void {
+    this.db
+      .update(scheduledTaskRuns)
+      .set({
+        status: 'interrupted',
+        finishedAt: new Date(this.nowMs()),
+        error: 'Interrupted before it finished — the app closed while the run was in progress.',
+      })
+      .where(eq(scheduledTaskRuns.status, 'running'))
+      .run();
+  }
+
   /** Schedule every enabled task and catch up anything missed while closed.
    *  Returns the catch-up promise so callers (tests) can await the missed runs;
    *  the boot path ignores it (catch-up proceeds in the background). */
   start(): Promise<void> {
+    this.reconcileOrphanedRuns();
     const now = this.nowMs();
     const missed: string[] = [];
     for (const task of this.list()) {

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -224,7 +224,7 @@ export const scheduledTaskRuns = sqliteTable(
       .notNull()
       .references(() => scheduledTasks.id, { onDelete: 'cascade' }),
     messageId: text('message_id'),
-    status: text({ enum: ['running', 'ok', 'error', 'skipped'] }).notNull(),
+    status: text({ enum: ['running', 'ok', 'error', 'skipped', 'interrupted'] }).notNull(),
     error: text(),
     startedAt: timestamp(),
     finishedAt: integer('finished_at', { mode: 'timestamp_ms' }),

--- a/src/renderer/src/components/scheduled/TaskDetail.tsx
+++ b/src/renderer/src/components/scheduled/TaskDetail.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from '@tanstack/react-router';
 import {
   CheckCircle2,
+  CircleSlash,
   LoaderCircle,
   MessageSquareText,
   Pause,
@@ -32,11 +33,14 @@ function Row({ label, children }: { label: string; children: React.ReactNode }):
 }
 
 // A run in progress spins; the rest are terminal outcomes with a static glyph.
+// `interrupted` is neutral (muted, not a red failure) — the run was cut short by
+// an app close/kill, not by the task itself erroring.
 const RUN_STATUS = {
   running: { Icon: LoaderCircle, color: 'text-accent', spin: true },
   ok: { Icon: CheckCircle2, color: 'text-success', spin: false },
   error: { Icon: XCircle, color: 'text-danger', spin: false },
   skipped: { Icon: Play, color: 'text-fg-tertiary', spin: false },
+  interrupted: { Icon: CircleSlash, color: 'text-fg-tertiary', spin: false },
 } as const;
 
 function RunRow({


### PR DESCRIPTION
## Problem
A scheduled task showed a permanent loading spinner in its run history even though no conversation was actually running.

## Root cause
`ScheduledTaskManager.fire()` inserts a run as `status='running'`, then updates it to a terminal status only *after* the agent turn completes. If the process dies mid-run — `Cmd+Q`, crash, or `kill`, none of which await the in-flight run — that terminal write never happens and the row is stranded at `running`. `start()` had no reconciliation step, so the orphan survived every restart.

The detail panel (`TaskDetail.tsx`) renders a run with `status==='running'` as a spinning loader and polls the runs query every 2s while any run is `running` — hence the endless spinner + background polling. Meanwhile `isRunning()` is in-memory only, so it correctly reports that nothing is running; the DB state and the live state were simply out of sync.

## Fix
- **Reconcile orphaned runs on startup** — any run still `running` when the manager boots is settled to a new `interrupted` status with `finishedAt` (`manager.ts`). Boot-only, so a genuinely live run is never caught.
- Add `interrupted` to the run-status enum — TS-only; the SQLite column is `text`, so **no migration** (`db:generate` confirms no drift).
- Render `interrupted` with a neutral muted glyph (`CircleSlash`), not a red error — the run was cut short, the task itself didn't fail.
- Test that `start()` settles the orphan and leaves finished runs alone.

## Verification
- 12 scheduled-manager tests pass; `bun run check` (biome + node/web typecheck) green.
- Ran the reconcile query against a **copy of the real DB**: the stuck run heals `running → interrupted` with `finishedAt` set, and the `ok`/`error` runs are untouched.

## Note
In-app **Stop** (app stays running) already syncs correctly — aborting finalizes the stream, which lets `fire()` write the terminal status. This PR only covers runs orphaned by process termination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
