### PR TITLE
fix(scheduled): rotate to a fresh thread when the bound one is archived or gone

### DIFF
--- a/src/main/agent/scheduled/manager.test.ts
+++ b/src/main/agent/scheduled/manager.test.ts
@@ -108,6 +108,51 @@ test('the bound thread is created on first fire and back-references the task', a
   expect((thread?.metadata as { scheduledTaskId?: string })?.scheduledTaskId).toBe(task.id);
 });
 
+test('a task with a live bound thread keeps the same thread across runs', async () => {
+  const { mgr } = setup(async () => ({ status: 'ok' }));
+  const task = mgr.create({ ...RECURRING });
+  await mgr.runNow(task.id);
+  const first = view(mgr, task.id).threadId;
+  await mgr.runNow(task.id);
+  expect(view(mgr, task.id).threadId).toBe(first);
+});
+
+test('a run whose bound thread was archived rotates to a fresh thread, leaving the old one', async () => {
+  const { mgr, db } = setup(async () => ({ status: 'ok' }));
+  const task = mgr.create({ ...RECURRING });
+  await mgr.runNow(task.id);
+  const first = view(mgr, task.id).threadId as string;
+
+  // The user archives the bound conversation (done with it).
+  db.update(threads)
+    .set({ archivedAt: new Date(START) })
+    .where(eq(threads.id, first))
+    .run();
+
+  await mgr.runNow(task.id);
+  const second = view(mgr, task.id).threadId;
+  expect(second).toBeTruthy();
+  expect(second).not.toBe(first);
+  // The archived thread is left intact, still recoverable.
+  expect(db.select().from(threads).where(eq(threads.id, first)).get()?.archivedAt).toBeInstanceOf(
+    Date,
+  );
+});
+
+test('a run whose bound thread was deleted rebinds to a fresh thread instead of erroring', async () => {
+  const { mgr, db } = setup(async () => ({ status: 'ok' }));
+  const task = mgr.create({ ...RECURRING });
+  await mgr.runNow(task.id);
+  const first = view(mgr, task.id).threadId as string;
+
+  db.delete(threads).where(eq(threads.id, first)).run();
+
+  await mgr.runNow(task.id);
+  const second = view(mgr, task.id).threadId;
+  expect(second).toBeTruthy();
+  expect(second).not.toBe(first);
+});
+
 test('runNow records a run; last-run + status derive from it', async () => {
   const { mgr } = setup(async () => ({ status: 'ok', messageId: 'msg-1' }));
   const task = mgr.create({ ...RECURRING });

--- a/src/main/agent/scheduled/manager.ts
+++ b/src/main/agent/scheduled/manager.ts
@@ -311,9 +311,23 @@ export class ScheduledTaskManager {
   }
 
   /** Create the task's bound thread on first fire and record it on the task. The
-   *  thread carries a back-reference so the sidebar can tell it from a plain chat. */
+   *  thread carries a back-reference so the sidebar can tell it from a plain chat.
+   *
+   *  Reuse the bound thread only while it's a live conversation. If the user
+   *  archived it (they're done with it) or deleted it, rotate to a fresh thread
+   *  and rebind — the next run continues in a visible conversation instead of
+   *  silently appending to a hidden one (archiving never clears archivedAt) or
+   *  failing against a gone one. The old thread is left as-is, still recoverable
+   *  from the archive. */
   private ensureThread(task: ScheduledTask): ScheduledTask {
-    if (task.threadId) return task;
+    if (task.threadId) {
+      const bound = this.db
+        .select({ archivedAt: threads.archivedAt })
+        .from(threads)
+        .where(eq(threads.id, task.threadId))
+        .get();
+      if (bound && bound.archivedAt == null) return task;
+    }
     const threadId = randomUUID();
     this.db
       .insert(threads)


### PR DESCRIPTION
## Problem
When a scheduled task's bound conversation is archived, the next run silently appends to that hidden thread instead of continuing in a visible one.

## Root cause
`ScheduledTaskManager.ensureThread()` only checked whether a `threadId` was set (`if (task.threadId) return task`). Archiving a thread just sets `archivedAt` — the thread stays in the DB, drops out of the sidebar list, and message persistence only bumps `updatedAt`, never clears `archivedAt`. So a task bound to an archived thread keeps writing into it forever, invisibly.

A *deleted* bound thread was worse: the run inserts against a non-existent thread, hits the `messages` foreign key, and fails every time — eventually tripping the consecutive-failure auto-pause.

## Fix
`ensureThread` now reuses the bound thread only while it's a **live** conversation — it exists and isn't archived. Otherwise it mints a fresh thread and rebinds the task, so the next run continues in a new, visible conversation. The old thread is left as-is, still recoverable from the archive. Rotation is lazy (on the next fire), matching the existing lazy-thread-creation pattern.

## Verification
- 14 scheduled-manager tests pass — 3 new: a live thread is reused across runs; an archived thread rotates and the old one is preserved; a deleted thread rebinds instead of erroring. `bun run check` (biome + node/web typecheck) green.
- Confirmed against real data: the live "Summarize AI news" task is currently bound to an archived thread, so with this fix its next run rotates to a fresh conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
