### PR TITLE
fix(tools): make web_search honor the abort signal so stop is immediate

### DIFF
--- a/src/main/agent/tools/builtins/web-search.ts
+++ b/src/main/agent/tools/builtins/web-search.ts
@@ -10,9 +10,9 @@ export const webSearchTool = () =>
     inputSchema: z.object({
       query: z.string().min(1).describe('The search query.'),
     }),
-    execute: async ({ query }) => {
+    execute: async ({ query }, { abortSignal }) => {
       try {
-        const results = await runSearch(DDG, query);
+        const results = await runSearch(DDG, query, abortSignal);
         return formatResults(query, results);
       } catch (err) {
         return `Error: ${err instanceof Error ? err.message : String(err)}`;

--- a/src/main/agent/tools/builtins/web/run-search.test.ts
+++ b/src/main/agent/tools/builtins/web/run-search.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'bun:test';
+import { DDG } from './engines';
+import { runSearch } from './run-search';
+
+// The full browser flow needs Electron (unavailable here), but the abort entry
+// guard runs before any window is opened, so it's exercisable under bun: an
+// already-aborted signal must reject fast rather than reach the BrowserWindow.
+test('runSearch rejects immediately for an already-aborted signal, opening no window', async () => {
+  const controller = new AbortController();
+  controller.abort();
+  await expect(runSearch(DDG, 'anything', controller.signal)).rejects.toThrow(/abort/i);
+});

--- a/src/main/agent/tools/builtins/web/run-search.ts
+++ b/src/main/agent/tools/builtins/web/run-search.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow } from 'electron';
+import type { WebContents } from 'electron';
 import type { SearchEngine, SearchResult } from './engines';
 
 const NAV_TIMEOUT_MS = 15_000;
@@ -20,30 +20,59 @@ const RETRY_BACKOFF_MS = 2_500;
 let queue: Promise<unknown> = Promise.resolve();
 let lastSearchEndedAt = 0;
 
+// Electron is required lazily so this module imports cleanly outside an Electron
+// runtime (e.g. the bun test runner), matching how the agent runner defers it.
+function BrowserWindowCtor(): typeof import('electron').BrowserWindow {
+  return (require('electron') as typeof import('electron')).BrowserWindow;
+}
+
+function abortError(): DOMException {
+  return new DOMException('The web search was aborted.', 'AbortError');
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw abortError();
+}
+
 /**
  * Run a web search through a hidden BrowserWindow. Serialized and throttled
  * against the engine's rate limiting (see MIN_GAP_MS), with one retry on a
  * navigation failure. A real Chromium clears the bot challenge a plain fetch
  * can't; the window is always destroyed, even on error/timeout.
+ *
+ * The abort signal (the run's stop) is honored end-to-end: every wait rejects on
+ * abort and the in-flight window is torn down, so stopping a turn mid-search
+ * returns at once instead of blocking on the navigation/poll timeouts.
  */
-export async function runSearch(engine: SearchEngine, query: string): Promise<SearchResult[]> {
-  const run = queue.then(() => throttledSearch(engine, query));
+export async function runSearch(
+  engine: SearchEngine,
+  query: string,
+  signal?: AbortSignal,
+): Promise<SearchResult[]> {
+  const run = queue.then(() => throttledSearch(engine, query, signal));
   // Keep the chain alive whatever this run does, so one failure can't wedge it.
   queue = run.catch(() => {});
   return run;
 }
 
-async function throttledSearch(engine: SearchEngine, query: string): Promise<SearchResult[]> {
+async function throttledSearch(
+  engine: SearchEngine,
+  query: string,
+  signal?: AbortSignal,
+): Promise<SearchResult[]> {
+  throwIfAborted(signal);
   const sinceLast = Date.now() - lastSearchEndedAt;
-  if (sinceLast < MIN_GAP_MS) await delay(MIN_GAP_MS - sinceLast);
+  if (sinceLast < MIN_GAP_MS) await delay(MIN_GAP_MS - sinceLast, signal);
   try {
     let lastErr: unknown;
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      throwIfAborted(signal);
       try {
-        return await attemptSearch(engine, query);
+        return await attemptSearch(engine, query, signal);
       } catch (err) {
+        if (signal?.aborted) throw err; // a stop isn't a retryable failure
         lastErr = err;
-        if (attempt < MAX_ATTEMPTS) await delay(RETRY_BACKOFF_MS);
+        if (attempt < MAX_ATTEMPTS) await delay(RETRY_BACKOFF_MS, signal);
       }
     }
     throw lastErr;
@@ -52,41 +81,66 @@ async function throttledSearch(engine: SearchEngine, query: string): Promise<Sea
   }
 }
 
-async function attemptSearch(engine: SearchEngine, query: string): Promise<SearchResult[]> {
-  const win = new BrowserWindow({
+async function attemptSearch(
+  engine: SearchEngine,
+  query: string,
+  signal?: AbortSignal,
+): Promise<SearchResult[]> {
+  const win = new (BrowserWindowCtor())({
     show: false,
     width: 1024,
     height: 768,
     // No images and no node integration — we only need the rendered DOM text.
     webPreferences: { images: false, nodeIntegration: false, contextIsolation: true },
   });
+  // A stop mid-search destroys the window now, so the in-flight loadURL / poll
+  // rejects immediately instead of running to its own multi-second timeout.
+  const onAbort = (): void => {
+    if (!win.isDestroyed()) win.destroy();
+  };
+  signal?.addEventListener('abort', onAbort, { once: true });
   try {
+    throwIfAborted(signal);
     const wc = win.webContents;
     await withTimeout(wc.loadURL(engine.buildUrl(query)), NAV_TIMEOUT_MS, 'navigation');
-    await pollFor(wc, engine.readyExpr, RESULTS_TIMEOUT_MS);
+    await pollFor(wc, engine.readyExpr, RESULTS_TIMEOUT_MS, signal);
     const raw = await wc.executeJavaScript(engine.scrapeScript);
     return engine.parse(Array.isArray(raw) ? raw : []);
   } finally {
+    signal?.removeEventListener('abort', onAbort);
     if (!win.isDestroyed()) win.destroy();
   }
 }
 
 /** Resolve once the in-page count expression goes truthy, or stop at timeout. */
 async function pollFor(
-  wc: Electron.WebContents,
+  wc: WebContents,
   countExpr: string,
   timeoutMs: number,
+  signal?: AbortSignal,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
+    throwIfAborted(signal);
     const n = await wc.executeJavaScript(countExpr).catch(() => 0);
     if (n) return;
-    await delay(POLL_INTERVAL_MS);
+    await delay(POLL_INTERVAL_MS, signal);
   }
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(abortError());
+  return new Promise((resolve, reject) => {
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(abortError());
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {


### PR DESCRIPTION
## Problem
While a scheduled task (or any turn) was running `web_search`, pressing ESC or the composer's stop button did not terminate immediately — the turn hung for tens of seconds before stopping.

## Root cause
The stop wiring is correct (ESC and the stop button both `POST /api/chat/:threadId/abort` → `abortThreadRun` → `controller.abort()`, which aborts `streamText`). The problem is at the tool layer: the AI SDK only settles a turn once the in-flight tool's `execute()` resolves, and `web_search` never observed the abort signal. It drives a hidden `BrowserWindow` (`loadURL`, 15s nav timeout + 12s result poll, up to 2 attempts, plus a throttle gap) with no signal awareness, so a stop had to wait for the search to reach its own ~30–60s timeout. `web_fetch` by contrast already cancels its fetch, so it's the search step that hangs.

## Fix
Thread the abort signal end-to-end through `runSearch` / `throttledSearch` / `attemptSearch` / `pollFor`:
- every wait (throttle, retry backoff, result poll) rejects on abort via an abortable `delay` + `throwIfAborted`;
- `attemptSearch` destroys the in-flight `BrowserWindow` on abort, so `loadURL`/`executeJavaScript` reject immediately;
- an abort isn't treated as a retryable failure.

`electron` is now required lazily (matching `agent/run.ts`'s pattern) so the module imports cleanly under bun for the abort test.

## Audit of the other builtin tools (requested)
`web_search` was the only offender. The rest are already correct:
- `bash` → `sandbox.exec` kills the whole process tree on abort;
- `web_fetch` → cancels the fetch (`AbortSignal.any` with a timeout);
- `image_gen` → threads `abortSignal` to `generateThreadImage`;
- `task` → threads it to the subagent;
- MCP adapter → passes `{ signal }` to `callTool`;
- read/write/edit/glob/grep/list-dir/memory/todo/… do only fast local work.

## Verification
- 13 web-tool tests pass, including a new one: an already-aborted signal makes `runSearch` reject immediately without opening a window. `bun run check` (biome + node/web typecheck) green.
- The full browser-teardown-on-abort path needs Electron (not runnable under bun); verified by reasoning. Recommend a quick manual check: run a `web_search`, hit stop mid-search, confirm it stops at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
