### PR TITLE
fix(agent): seal dangling tool calls so an interrupted turn can't wedge the thread

### DIFF
--- a/src/main/agent/middleware/builtins/persistence.test.ts
+++ b/src/main/agent/middleware/builtins/persistence.test.ts
@@ -38,3 +38,18 @@ test('afterRun marks a user-aborted turn as read so it skips the unread dot', as
 
   expect(calls[0]?.opts).toEqual({ markRead: true });
 });
+
+test('afterRun seals a dangling tool call before persisting the aborted message', async () => {
+  const { calls, mw } = capture();
+  const dangling = {
+    id: 'm2',
+    role: 'assistant',
+    parts: [{ type: 'tool-web_search', toolCallId: 'c1', state: 'input-available', input: {} }],
+  } as RunResultInfo['message'];
+
+  await mw.afterRun?.(ctx, { message: dangling, aborted: true });
+
+  const part = calls[0]?.message.parts[0] as Record<string, unknown>;
+  expect(part.state).toBe('output-error');
+  expect(part.toolCallId).toBe('c1');
+});

--- a/src/main/agent/middleware/builtins/persistence.ts
+++ b/src/main/agent/middleware/builtins/persistence.ts
@@ -1,5 +1,6 @@
 import type { UIMessage } from 'ai';
 import type { Db } from '../../../db';
+import { sealMessageToolCalls } from '../shared/seal-tool-calls';
 import type { AgentMiddleware } from '../types';
 
 export type PersistFn = (
@@ -23,7 +24,12 @@ export function persistenceMiddleware(persist: PersistFn): AgentMiddleware {
   return {
     name: 'persistence',
     afterRun(ctx, result) {
-      persist(ctx.db, ctx.threadId, result.message, { markRead: result.aborted });
+      // Seal any tool call that never returned before persisting: an aborted turn
+      // leaves dangling tool_use parts that would break the thread's next request
+      // (no-op when the turn finished cleanly).
+      persist(ctx.db, ctx.threadId, sealMessageToolCalls(result.message), {
+        markRead: result.aborted,
+      });
     },
   };
 }

--- a/src/main/agent/middleware/builtins/seal-tool-calls.ts
+++ b/src/main/agent/middleware/builtins/seal-tool-calls.ts
@@ -1,0 +1,19 @@
+import { sealDanglingToolCalls } from '../shared/seal-tool-calls';
+import type { AgentMiddleware, RunContext } from '../types';
+
+/**
+ * Backstop: before the model call, seal any dangling tool call left in the
+ * history by an interrupted earlier turn (a user stop, a crash, a killed
+ * scheduled run). A tool_use with no tool_result makes the provider reject the
+ * whole request, so this keeps one corrupted message from wedging every future
+ * turn on the thread. Request-only — it sanitizes what the model sees and does
+ * not rewrite the stored message; the persistence path seals that at write time.
+ */
+export function toolCallSealerMiddleware(): AgentMiddleware {
+  return {
+    name: 'tool-call-sealer',
+    beforeRun(ctx: RunContext): void {
+      ctx.request.messages = sealDanglingToolCalls(ctx.request.messages);
+    },
+  };
+}

--- a/src/main/agent/middleware/index.ts
+++ b/src/main/agent/middleware/index.ts
@@ -10,6 +10,7 @@ export { type MemoryOptions, memoryMiddleware } from './builtins/memory';
 export { metadataMiddleware } from './builtins/metadata';
 export { type PersistFn, persistenceMiddleware } from './builtins/persistence';
 export { type ProfileOptions, profileMiddleware } from './builtins/profile';
+export { toolCallSealerMiddleware } from './builtins/seal-tool-calls';
 export { type SkillsOptions, skillsMiddleware } from './builtins/skills';
 export { type SetTitleFn, titleMiddleware } from './builtins/title';
 export { usageMiddleware } from './builtins/usage';

--- a/src/main/agent/middleware/shared/seal-tool-calls.test.ts
+++ b/src/main/agent/middleware/shared/seal-tool-calls.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from 'bun:test';
+import type { UIMessage } from 'ai';
+import { sealDanglingToolCalls, sealMessageToolCalls } from './seal-tool-calls';
+
+function assistant(parts: unknown[]): UIMessage {
+  return { id: 'm1', role: 'assistant', parts } as UIMessage;
+}
+
+test('seals an input-available tool call to output-error, preserving id/input', () => {
+  const msg = assistant([
+    { type: 'tool-web_search', toolCallId: 'c1', state: 'input-available', input: { query: 'x' } },
+  ]);
+  const [part] = sealMessageToolCalls(msg).parts as Array<Record<string, unknown>>;
+  expect(part.state).toBe('output-error');
+  expect(part.errorText).toBeTruthy();
+  expect(part.toolCallId).toBe('c1');
+  expect(part.input).toEqual({ query: 'x' });
+});
+
+test('seals input-streaming and dynamic-tool calls too', () => {
+  const msg = assistant([
+    { type: 'tool-bash', toolCallId: 'c2', state: 'input-streaming', input: {} },
+    { type: 'dynamic-tool', toolName: 'mcp__x__y', toolCallId: 'c3', state: 'input-available' },
+  ]);
+  const parts = sealMessageToolCalls(msg).parts as Array<Record<string, unknown>>;
+  expect(parts[0].state).toBe('output-error');
+  expect(parts[1].state).toBe('output-error');
+});
+
+test('leaves resolved tool calls, text, and user messages untouched (same reference)', () => {
+  const done = assistant([
+    { type: 'text', text: 'hi', state: 'done' },
+    { type: 'tool-web_search', toolCallId: 'c4', state: 'output-available', output: 'r' },
+    { type: 'tool-web_fetch', toolCallId: 'c5', state: 'output-error', errorText: 'boom' },
+  ]);
+  expect(sealMessageToolCalls(done)).toBe(done);
+
+  const user = { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'q' }] } as UIMessage;
+  expect(sealMessageToolCalls(user)).toBe(user);
+});
+
+test('sealDanglingToolCalls only rebuilds the messages that had a dangling call', () => {
+  const clean = assistant([
+    { type: 'tool-web_search', toolCallId: 'a', state: 'output-available' },
+  ]);
+  const dirty = assistant([{ type: 'tool-web_search', toolCallId: 'b', state: 'input-available' }]);
+  const out = sealDanglingToolCalls([clean, dirty]);
+  expect(out[0]).toBe(clean);
+  expect(out[1]).not.toBe(dirty);
+  expect((out[1].parts[0] as Record<string, unknown>).state).toBe('output-error');
+});

--- a/src/main/agent/middleware/shared/seal-tool-calls.ts
+++ b/src/main/agent/middleware/shared/seal-tool-calls.ts
@@ -1,0 +1,34 @@
+import { isToolOrDynamicToolUIPart, type UIMessage } from 'ai';
+
+type Part = UIMessage['parts'][number];
+
+const SEAL_ERROR = 'Stopped before the tool returned.';
+
+/** A tool call still awaiting its result — persisted this way it's a dangling
+ *  tool_use with no matching tool_result. */
+function isDangling(part: Part): boolean {
+  return (
+    isToolOrDynamicToolUIPart(part) &&
+    (part.state === 'input-streaming' || part.state === 'input-available')
+  );
+}
+
+/**
+ * Seal tool calls that never returned. A turn cut short — the user stops it, or
+ * the process is killed mid scheduled run — leaves its emitted tool calls at
+ * 'input-available' / 'input-streaming'. A model provider rejects a request whose
+ * history holds a tool_use with no tool_result, so flip each unfinished call to a
+ * terminal 'output-error', keeping tool_use <-> tool_result paired. A message
+ * with nothing dangling is returned unchanged (same reference).
+ */
+export function sealMessageToolCalls(msg: UIMessage): UIMessage {
+  if (!msg.parts.some(isDangling)) return msg;
+  const parts = msg.parts.map((part) =>
+    isDangling(part) ? ({ ...part, state: 'output-error', errorText: SEAL_ERROR } as Part) : part,
+  );
+  return { ...msg, parts };
+}
+
+export function sealDanglingToolCalls(messages: UIMessage[]): UIMessage[] {
+  return messages.map(sealMessageToolCalls);
+}

--- a/src/main/server/http.ts
+++ b/src/main/server/http.ts
@@ -19,6 +19,7 @@ import {
   profileMiddleware,
   skillsMiddleware,
   titleMiddleware,
+  toolCallSealerMiddleware,
   usageMiddleware,
 } from '../agent/middleware';
 import { isImageModel, maxContextTokens, modelPricing } from '../agent/models/catalog';
@@ -236,6 +237,10 @@ export function startHttpServer(deps: {
       // original first user message into a summary, and their injected blocks have
       // to land on whatever the post-compaction first user message is.
       middlewares: [
+        // Backstop first: seal any dangling tool call an interrupted earlier turn
+        // left in the history, before compaction or convertToModelMessages sees it
+        // — a tool_use with no tool_result would otherwise fail the whole request.
+        toolCallSealerMiddleware(),
         // Title is generated from the first user message, so it must run before
         // the skills middleware injects its index into that message (and before
         // compaction could fold it) — otherwise the title summarizes the skill


### PR DESCRIPTION
## Problem
A scheduled task's conversation ended up with `web_search` tool calls that had **no result** — the tool result was "lost." More seriously, a persisted message with a tool call that never returned is a dangling `tool_use` with no `tool_result`, which a provider rejects — so one interrupted turn can break every future turn on that thread.

## Root cause
The AI SDK only waits for a tool's `execute()` on a **normal** finish. When a turn is **aborted** (the user stops it) or its process is killed mid scheduled run, `streamText` stops immediately and hands `onFinish` the *partial* assistant message — the tool calls it already emitted stay at `input-available`/`input-streaming`. `persistenceMiddleware.afterRun` then persisted that message **verbatim**. (Confirmed on real data: a message with 5 `web_search` parts stuck at `input-available`, and metadata carrying only `createdAt` — no `finishReason` — proving it never finished normally.)

The codebase already knew dangling `tool_use` breaks the next request — `resolveToolOutput` repairs it — but only for the clarification-cancel flow, never for a general stop.

## Fix — two layers, one shared helper
`sealMessageToolCalls` / `sealDanglingToolCalls` flip any tool part still at `input-streaming`/`input-available` to a terminal `output-error`, keeping `tool_use ↔ tool_result` paired (unchanged messages returned by reference).

- **Backstop** (`toolCallSealerMiddleware`, `beforeRun`, runs first): sanitizes the loaded history before compaction / `convertToModelMessages`, so a dangling call from **any** source (stop, crash, orphaned run, already-corrupted row) can't fail the request. Request-only — it does not rewrite the stored message.
- **Abort-seal** (`persistenceMiddleware.afterRun`): seals the message before persisting, so the stored row and the UI are never left dangling.

## Verification
- 57 middleware tests pass, including new coverage: the helper seals `input-available`/`input-streaming`/`dynamic-tool` calls, leaves resolved calls / text / user messages untouched (same reference), and `afterRun` seals a dangling call before persisting.
- `bun run check` (biome + node/web typecheck) green.
- Ran the helper against the real corrupted message from the DB: its 5 dangling `input-available` calls all seal to `output-error`, the 3 resolved parts untouched — so that thread's next turn no longer errors.

## Related
Companion to #40 (make `web_search` honor the abort signal): #40 makes stop *fast*; this makes an interrupted turn not *corrupt* the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
