### PR TITLE
feat(settings): add UI font and global font size to appearance

### DIFF
--- a/src/renderer/src/assets/styles.css
+++ b/src/renderer/src/assets/styles.css
@@ -89,13 +89,13 @@ body,
    text-* utilities, which read these --text-* tokens — redefining them here
    scales the whole block down a notch without touching the rest of the app. */
 .atrium-md {
-  --text-xs: 0.7rem;
-  --text-sm: 0.8rem;
-  --text-base: 0.875rem;
-  --text-lg: 1rem;
-  --text-xl: 1.1rem;
-  --text-2xl: 1.35rem;
-  --text-3xl: 1.6rem;
+  --text-xs: calc(0.7rem * var(--ui-scale));
+  --text-sm: calc(0.8rem * var(--ui-scale));
+  --text-base: calc(0.875rem * var(--ui-scale));
+  --text-lg: calc(1rem * var(--ui-scale));
+  --text-xl: calc(1.1rem * var(--ui-scale));
+  --text-2xl: calc(1.35rem * var(--ui-scale));
+  --text-3xl: calc(1.6rem * var(--ui-scale));
 }
 
 /* Streamdown defaults to list-inside; outside markers so wraps hang-indent. */

--- a/src/renderer/src/assets/tokens.css
+++ b/src/renderer/src/assets/tokens.css
@@ -13,19 +13,25 @@
 
 :root {
   /* ── Type families ── */
-  --font-sans: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif;
+  /* The base system stack stays fixed; the user's custom UI font (appearance
+     setting) is prepended onto --font-sans at runtime, keeping this as fallback. */
+  --font-sans-system: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif;
+  --font-sans: var(--font-sans-system);
   --font-mono: "JetBrains Mono", "SF Mono", ui-monospace, "Menlo", monospace;
 
   /* ── Type scale ── */
-  --text-2xs: 10.5px;
-  --text-xs:  11.5px;
-  --text-sm:  12.5px;
-  --text-base: 13.5px;
-  --text-md:  14.5px;
-  --text-lg:  16px;
-  --text-xl:  20px;
-  --text-2xl: 24px;
-  --text-3xl: 32px;
+  /* --ui-scale (default 1) is set from the appearance font-size step; every size
+     multiplies through it so app chrome, chat text, and code resize together. */
+  --ui-scale: 1;
+  --text-2xs: calc(10.5px * var(--ui-scale));
+  --text-xs:  calc(11.5px * var(--ui-scale));
+  --text-sm:  calc(12.5px * var(--ui-scale));
+  --text-base: calc(13.5px * var(--ui-scale));
+  --text-md:  calc(14.5px * var(--ui-scale));
+  --text-lg:  calc(16px * var(--ui-scale));
+  --text-xl:  calc(20px * var(--ui-scale));
+  --text-2xl: calc(24px * var(--ui-scale));
+  --text-3xl: calc(32px * var(--ui-scale));
 
   /* ── Weights ── */
   --weight-regular: 400;

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -391,6 +391,16 @@ export const en: typeof zh = {
       darkDesc: 'Studio theme',
       systemDesc: 'Follow the system',
       note: 'Changes apply immediately. System mode follows the macOS appearance preference.',
+      textGroup: 'Text',
+      uiFont: 'UI font',
+      uiFontDesc:
+        'Font family for the app. Install the font on your system first; leave empty for the default.',
+      uiFontPlaceholder: 'e.g. Inter',
+      fontSize: 'Font size',
+      fontSizeDesc: 'Scales all text — app, chats, and code — together.',
+      fontSizeSmall: 'Small',
+      fontSizeDefault: 'Default',
+      fontSizeLarge: 'Large',
     },
     about: {
       description:

--- a/src/renderer/src/i18n/zh.ts
+++ b/src/renderer/src/i18n/zh.ts
@@ -391,6 +391,15 @@ export const zh = {
       darkDesc: 'Studio 主题',
       systemDesc: '跟随系统外观',
       note: '切换会立即生效。System 模式会跟随 macOS 外观偏好自动变换。',
+      textGroup: '文字',
+      uiFont: '界面字体',
+      uiFontPlaceholder: '例如 Inter',
+      uiFontDesc: '应用界面使用的字体。请先在系统中安装该字体；留空则用默认字体。',
+      fontSize: '字号',
+      fontSizeDesc: '整体缩放所有文字——界面、聊天和代码。',
+      fontSizeSmall: '小',
+      fontSizeDefault: '默认',
+      fontSizeLarge: '大',
     },
     about: {
       description:

--- a/src/renderer/src/lib/use-appearance-vars.ts
+++ b/src/renderer/src/lib/use-appearance-vars.ts
@@ -1,0 +1,37 @@
+import type { UiFontSize } from '@shared/settings';
+import { useEffect } from 'react';
+import { useSetting } from './use-setting';
+
+/** Multiplier each discrete font-size step applies to the whole type scale. */
+const FONT_SCALE: Record<UiFontSize, number> = {
+  small: 0.9,
+  default: 1,
+  large: 1.1,
+};
+
+/**
+ * Mirror the user's appearance prefs onto :root as CSS vars so the whole app —
+ * chrome and content, chat and settings — follows them. Mounted once at the
+ * router root.
+ *
+ * The UI font is a user-typed name that may not be installed, so it's prepended
+ * onto the base system stack (--font-sans-system) rather than replacing it: an
+ * unavailable or misspelled name degrades to the default face instead of an
+ * unstyled fallback. The font size drives --ui-scale, which the type-scale
+ * tokens multiply through (tokens.css / .atrium-md).
+ */
+export function useAppearanceVars(): void {
+  const { value: uiFont } = useSetting('appearance.uiFont');
+  const { value: uiFontSize } = useSetting('appearance.uiFontSize');
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const name = uiFont.trim();
+    if (name) root.style.setProperty('--font-sans', `"${name}", var(--font-sans-system)`);
+    else root.style.removeProperty('--font-sans');
+  }, [uiFont]);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--ui-scale', String(FONT_SCALE[uiFontSize]));
+  }, [uiFontSize]);
+}

--- a/src/renderer/src/routes/__root.tsx
+++ b/src/renderer/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import { CommandPalette } from '../components/CommandPalette';
 import { Toaster } from '../components/Toaster';
 import { UpdateDialog } from '../components/UpdateDialog';
 import { trpc } from '../lib/trpc';
+import { useAppearanceVars } from '../lib/use-appearance-vars';
 import { useKeybindings } from '../lib/use-keybindings';
 import { useLanguage } from '../lib/use-language';
 import { useUpdateSync } from '../lib/use-update-sync';
@@ -12,6 +13,7 @@ import { toast } from '../state/toast-store';
 
 function Root(): React.JSX.Element {
   useLanguage(); // apply the persisted UI language on load
+  useAppearanceVars(); // mirror font / code-size prefs onto :root CSS vars
   useKeybindings(); // global app shortcuts (⌘K/⌘N/⌘B/⌘,)
   useUpdateSync(); // mirror main-process updater state into the store
   const navigate = useNavigate();

--- a/src/renderer/src/routes/settings/$section.tsx
+++ b/src/renderer/src/routes/settings/$section.tsx
@@ -1,4 +1,4 @@
-import type { ComposerSendKey } from '@shared/settings';
+import type { ComposerSendKey, UiFontSize } from '@shared/settings';
 import type { UpdaterStage } from '@shared/update';
 import { createFileRoute, notFound } from '@tanstack/react-router';
 import type { ParseKeys } from 'i18next';
@@ -237,6 +237,8 @@ function AppearanceSection(): React.JSX.Element {
   const { t } = useTranslation();
   const theme = useThemeStore((s) => s.theme);
   const setTheme = useThemeStore((s) => s.setTheme);
+  const { value: uiFont, set: setUiFont } = useSetting('appearance.uiFont');
+  const { value: uiFontSize, set: setUiFontSize } = useSetting('appearance.uiFontSize');
 
   const tiles: Array<{ value: Theme; label: string; desc: string; icon: typeof Sun }> = [
     { value: 'light', label: 'Light', desc: t('settings.appearance.lightDesc'), icon: Sun },
@@ -244,38 +246,82 @@ function AppearanceSection(): React.JSX.Element {
     { value: 'system', label: 'System', desc: t('settings.appearance.systemDesc'), icon: Monitor },
   ];
 
+  const fontSizeOptions: ReadonlyArray<{ value: UiFontSize; label: string }> = [
+    { value: 'small', label: t('settings.appearance.fontSizeSmall') },
+    { value: 'default', label: t('settings.appearance.fontSizeDefault') },
+    { value: 'large', label: t('settings.appearance.fontSizeLarge') },
+  ];
+
+  const inputClass =
+    'rounded-md border border-border-default bg-elevated px-2.5 py-1.5 text-fg-primary text-sm focus:border-border-focus focus:outline-none';
+
   return (
-    <section>
-      <h2 className="mb-3 font-medium text-fg-primary text-sm">{t('settings.appearance.theme')}</h2>
-      <div className="grid grid-cols-3 gap-3">
-        {tiles.map((tile) => {
-          const Icon = tile.icon;
-          const isActive = theme === tile.value;
-          return (
-            <button
-              type="button"
-              key={tile.value}
-              onClick={() => setTheme(tile.value)}
-              className={`relative flex flex-col gap-2 rounded-lg border px-4 py-4 text-left transition-colors ${
-                isActive
-                  ? 'border-accent bg-accent-soft'
-                  : 'border-border-default bg-surface hover:border-border-strong'
-              }`}
-            >
-              <div className="flex items-center justify-between">
-                <Icon className={`size-[18px] ${isActive ? 'text-accent' : 'text-fg-secondary'}`} />
-                {isActive && <Check className="size-[14px] text-accent" />}
-              </div>
-              <div>
-                <div className="font-medium text-fg-primary text-sm">{tile.label}</div>
-                <div className="text-fg-tertiary text-xs">{tile.desc}</div>
-              </div>
-            </button>
-          );
-        })}
-      </div>
-      <p className="mt-4 text-fg-tertiary text-xs">{t('settings.appearance.note')}</p>
-    </section>
+    <div className="flex flex-col gap-8">
+      <section>
+        <h2 className="mb-3 font-medium text-fg-primary text-sm">
+          {t('settings.appearance.theme')}
+        </h2>
+        <div className="grid grid-cols-3 gap-3">
+          {tiles.map((tile) => {
+            const Icon = tile.icon;
+            const isActive = theme === tile.value;
+            return (
+              <button
+                type="button"
+                key={tile.value}
+                onClick={() => setTheme(tile.value)}
+                className={`relative flex flex-col gap-2 rounded-lg border px-4 py-4 text-left transition-colors ${
+                  isActive
+                    ? 'border-accent bg-accent-soft'
+                    : 'border-border-default bg-surface hover:border-border-strong'
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <Icon
+                    className={`size-[18px] ${isActive ? 'text-accent' : 'text-fg-secondary'}`}
+                  />
+                  {isActive && <Check className="size-[14px] text-accent" />}
+                </div>
+                <div>
+                  <div className="font-medium text-fg-primary text-sm">{tile.label}</div>
+                  <div className="text-fg-tertiary text-xs">{tile.desc}</div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+        <p className="mt-4 text-fg-tertiary text-xs">{t('settings.appearance.note')}</p>
+      </section>
+
+      <SettingGroup title={t('settings.appearance.textGroup')}>
+        <SettingRow
+          label={t('settings.appearance.uiFont')}
+          desc={t('settings.appearance.uiFontDesc')}
+          control={
+            <input
+              type="text"
+              value={uiFont}
+              onChange={(e) => setUiFont(e.target.value)}
+              placeholder={t('settings.appearance.uiFontPlaceholder')}
+              aria-label={t('settings.appearance.uiFont')}
+              className={`w-56 placeholder:text-fg-tertiary ${inputClass}`}
+            />
+          }
+        />
+        <SettingRow
+          label={t('settings.appearance.fontSize')}
+          desc={t('settings.appearance.fontSizeDesc')}
+          control={
+            <Select
+              value={uiFontSize}
+              onChange={setUiFontSize}
+              options={fontSizeOptions}
+              aria-label={t('settings.appearance.fontSize')}
+            />
+          }
+        />
+      </SettingGroup>
+    </div>
   );
 }
 

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -25,6 +25,11 @@ const selectedModelShape = z.object({ providerId: z.string(), modelId: z.string(
 export const COMPOSER_SEND_KEYS = ['enter', 'mod', 'shift'] as const;
 export type ComposerSendKey = (typeof COMPOSER_SEND_KEYS)[number];
 
+/** Discrete global text-size steps. Each maps to a scale multiplier applied to
+ *  the whole type scale in the renderer; 'default' is 1× (no change). */
+export const UI_FONT_SIZES = ['small', 'default', 'large'] as const;
+export type UiFontSize = (typeof UI_FONT_SIZES)[number];
+
 const generalShape = z.object({
   /** UI language; 'system' follows the OS locale. */
   language: z.enum(['system', 'en', 'zh']).default('system'),
@@ -48,6 +53,13 @@ const appearanceShape = z.object({
     maximized: false,
     fullscreen: false,
   }),
+  /** Custom app-chrome font family, typed by the user (they install the font
+   *  themselves). Empty = OS default stack. Applied with the system stack
+   *  appended as fallback, so an unavailable name degrades gracefully. */
+  uiFont: z.string().max(200).default(''),
+  /** Global text-size step; multiplies the whole type scale so app chrome, chat
+   *  text, and code resize together. */
+  uiFontSize: z.enum(UI_FONT_SIZES).default('default'),
 });
 
 const keyboardShape = z.object({


### PR DESCRIPTION
## What

Adds two controls to Settings → Appearance, backed by the `appearance` settings scope:

- **UI font** — free-text font family, applied *over* the system stack as a fallback so an unavailable or misspelled name degrades gracefully (empty = OS default, i.e. San Francisco on macOS).
- **Font size** — discrete global step (Small / Default / Large) driving a `--ui-scale` multiplier woven through the whole type scale (`tokens.css` + `.atrium-md`), so app chrome, chat text, and code resize together. Default is 1× — no visual change.

Applied to `:root` at the router root via a new `useAppearanceVars` hook.

## Notes

- Theme (light/dark/system) is unchanged.
- Syntax-highlighter / code-theme work is intentionally deferred to a separate "code rendering" epic (Shiki migration + diff panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)