### PR TITLE
Code rendering: Shiki highlighter + code theme setting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,10 +8,12 @@
         "@electron-toolkit/utils": "^4.0.0",
         "@mixmark-io/domino": "^2.2.0",
         "@radix-ui/react-select": "^2.3.1",
+        "@shikijs/stream": "^4.3.1",
         "ajv": "^8.20.0",
         "better-sqlite3": "^12.10.0",
         "electron-log": "^5.4.4",
         "jieba-wasm": "^2.4.0",
+        "shiki": "^4.3.1",
       },
       "devDependencies": {
         "@agentclientprotocol/sdk": "^0.25.0",
@@ -81,7 +83,6 @@
         "linkedom": "^0.18.12",
         "lucide-react": "^1.16.0",
         "mermaid": "^11.15.0",
-        "prism-react-renderer": "^2.4.1",
         "react": "^19.2.1",
         "react-activity-calendar": "^3.2.0",
         "react-day-picker": "^9",
@@ -677,6 +678,24 @@
 
     "@sentry/server-utils": ["@sentry/server-utils@10.60.0", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.15.0", "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0", "@apm-js-collab/tracing-hooks": "^0.10.0", "@sentry/conventions": "^0.12.0", "@sentry/core": "10.60.0", "magic-string": "~0.30.0" } }, "sha512-SX+MzWM3nz5ttKT48rlfktm0ERyIpDLma+b6pYeWgW2oFHKcpIu0g0qMGJrZs4lKM3MlgV7IqLa4texMqTp9kQ=="],
 
+    "@shikijs/core": ["@shikijs/core@4.3.1", "", { "dependencies": { "@shikijs/primitive": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg=="],
+
+    "@shikijs/langs": ["@shikijs/langs@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1" } }, "sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ=="],
+
+    "@shikijs/primitive": ["@shikijs/primitive@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A=="],
+
+    "@shikijs/stream": ["@shikijs/stream@4.3.1", "", { "dependencies": { "@shikijs/core": "4.3.1" }, "peerDependencies": { "react": "^19.0.0", "solid-js": "^1.9.0", "svelte": "^5.0.0-0", "vue": "^3.2.0" }, "optionalPeers": ["react", "solid-js", "svelte", "vue"] }, "sha512-QsZDisEVgtvnEgLftu/Ng5JkZlPn37AJoJQY330RnFoNcRtszr0JV3ldRLjIpgvl+qPRKF4t6h1P7FQhjQj6Sw=="],
+
+    "@shikijs/themes": ["@shikijs/themes@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1" } }, "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA=="],
+
+    "@shikijs/types": ["@shikijs/types@4.3.1", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
@@ -884,8 +903,6 @@
     "@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
 
     "@types/plist": ["@types/plist@3.0.5", "", { "dependencies": { "@types/node": "*", "xmlbuilder": ">=11.0.1" } }, "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA=="],
-
-    "@types/prismjs": ["@types/prismjs@1.26.6", "", {}, "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="],
 
     "@types/react": ["@types/react@19.2.15", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q=="],
 
@@ -1477,6 +1494,8 @@
 
     "hast-util-sanitize": ["hast-util-sanitize@5.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "unist-util-position": "^5.0.0" } }, "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg=="],
 
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
     "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
@@ -1847,6 +1866,10 @@
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "ora": ["ora@9.4.1", "", { "dependencies": { "chalk": "^5.6.2", "cli-cursor": "^5.0.0", "cli-spinners": "^3.2.0", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.1.0", "log-symbols": "^7.0.1", "stdin-discarder": "^0.3.2", "string-width": "^8.1.0" } }, "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw=="],
@@ -1914,8 +1937,6 @@
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
-
-    "prism-react-renderer": ["prism-react-renderer@2.4.1", "", { "dependencies": { "@types/prismjs": "^1.26.0", "clsx": "^2.0.0" }, "peerDependencies": { "react": ">=16.0.0" } }, "sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig=="],
 
     "proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
 
@@ -2019,6 +2040,12 @@
 
     "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
 
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
     "rehype-harden": ["rehype-harden@1.1.8", "", { "dependencies": { "unist-util-visit": "^5.0.0" } }, "sha512-Qn7vR1xrf6fZCrkm9TDWi/AB4ylrHy+jqsNm1EHOAmbARYA6gsnVJBq/sdBh6kmT4NEZxH5vgIjrscefJAOXcw=="],
 
     "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
@@ -2112,6 +2139,8 @@
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
+
+    "shiki": ["shiki@4.3.1", "", { "dependencies": { "@shikijs/core": "4.3.1", "@shikijs/engine-javascript": "4.3.1", "@shikijs/engine-oniguruma": "4.3.1", "@shikijs/langs": "4.3.1", "@shikijs/themes": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw=="],
 
     "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
 

--- a/package.json
+++ b/package.json
@@ -42,10 +42,12 @@
     "@electron-toolkit/utils": "^4.0.0",
     "@mixmark-io/domino": "^2.2.0",
     "@radix-ui/react-select": "^2.3.1",
+    "@shikijs/stream": "^4.3.1",
     "ajv": "^8.20.0",
     "better-sqlite3": "^12.10.0",
     "electron-log": "^5.4.4",
-    "jieba-wasm": "^2.4.0"
+    "jieba-wasm": "^2.4.0",
+    "shiki": "^4.3.1"
   },
   "devDependencies": {
     "@agentclientprotocol/sdk": "^0.25.0",
@@ -115,7 +117,6 @@
     "linkedom": "^0.18.12",
     "lucide-react": "^1.16.0",
     "mermaid": "^11.15.0",
-    "prism-react-renderer": "^2.4.1",
     "react": "^19.2.1",
     "react-activity-calendar": "^3.2.0",
     "react-day-picker": "^9",

--- a/src/renderer/src/components/Select.tsx
+++ b/src/renderer/src/components/Select.tsx
@@ -6,6 +6,8 @@ type SelectProps<T extends string> = {
   onChange: (value: T) => void;
   options: ReadonlyArray<{ value: T; label: string }>;
   'aria-label'?: string;
+  /** Extra classes for the trigger, e.g. `w-full` to fill a column. */
+  className?: string;
 };
 
 /** Compact dropdown over Radix Select — the default control for enumerated
@@ -16,12 +18,13 @@ export function Select<T extends string>({
   onChange,
   options,
   'aria-label': ariaLabel,
+  className,
 }: SelectProps<T>): React.JSX.Element {
   return (
     <RadixSelect.Root value={value} onValueChange={(v) => onChange(v as T)}>
       <RadixSelect.Trigger
         aria-label={ariaLabel}
-        className="inline-flex min-w-[150px] items-center justify-between gap-2 rounded-lg border border-border-default bg-surface py-1.5 pr-2.5 pl-3 text-fg-primary text-sm outline-0 transition-colors hover:border-border-strong focus:border-accent data-[state=open]:border-accent"
+        className={`inline-flex min-w-[150px] items-center justify-between gap-2 rounded-lg border border-border-default bg-surface py-1.5 pr-2.5 pl-3 text-fg-primary text-sm outline-0 transition-colors hover:border-border-strong focus:border-accent data-[state=open]:border-accent ${className ?? ''}`}
       >
         <RadixSelect.Value />
         <RadixSelect.Icon>

--- a/src/renderer/src/components/chat/CodeBlock.tsx
+++ b/src/renderer/src/components/chat/CodeBlock.tsx
@@ -25,7 +25,8 @@ import {
   SiYaml,
 } from 'react-icons/si';
 import { getTokenStyleObject, type ThemedToken } from 'shiki';
-import { DARK_THEME, highlighter, LIGHT_THEME, resolveLang } from '../../lib/code-highlighter';
+import { highlighter, resolveLang } from '../../lib/code-highlighter';
+import { useSetting } from '../../lib/use-setting';
 import { useThemeStore } from '../../state/theme-store';
 import { CopyButton } from './CopyButton';
 
@@ -82,9 +83,11 @@ const LANG_ICONS: Record<string, IconType> = {
  */
 export function CodeBlock({ code, lang }: { code: string; lang: string }): React.JSX.Element {
   const dark = useThemeStore((s) => s.resolvedTheme === 'dark');
+  const { value: codeThemeLight } = useSetting('appearance.codeThemeLight');
+  const { value: codeThemeDark } = useSetting('appearance.codeThemeDark');
   const Icon = LANG_ICONS[lang] ?? FileCode;
   const langId = resolveLang(lang);
-  const theme = dark ? DARK_THEME : LIGHT_THEME;
+  const theme = dark ? codeThemeDark : codeThemeLight;
 
   const [tokens, setTokens] = useState<ThemedToken[]>([]);
   const stream = useRef<{

--- a/src/renderer/src/components/chat/CodeBlock.tsx
+++ b/src/renderer/src/components/chat/CodeBlock.tsx
@@ -1,5 +1,6 @@
+import { ShikiStreamTokenizer } from '@shikijs/stream';
 import { FileCode } from 'lucide-react';
-import { Highlight, themes } from 'prism-react-renderer';
+import { useEffect, useRef, useState } from 'react';
 import type { IconType } from 'react-icons';
 import {
   SiC,
@@ -23,6 +24,8 @@ import {
   SiTypescript,
   SiYaml,
 } from 'react-icons/si';
+import { getTokenStyleObject, type ThemedToken } from 'shiki';
+import { DARK_THEME, highlighter, LIGHT_THEME, resolveLang } from '../../lib/code-highlighter';
 import { useThemeStore } from '../../state/theme-store';
 import { CopyButton } from './CopyButton';
 
@@ -65,13 +68,57 @@ const LANG_ICONS: Record<string, IconType> = {
 };
 
 /**
- * Fenced code block: Prism highlighting (synchronous, no wasm — reliable in
- * Electron) on our own code surface, with a header showing the language (brand
- * glyph + name) and a copy button.
+ * Fenced code block: Shiki highlighting on our own code surface, with a header
+ * (language glyph + name) and a copy button.
+ *
+ * Streaming is handled by @shikijs/stream's tokenizer: each render feeds only
+ * the newly-appended text (`enqueue(delta)`), and the tokenizer keeps its own
+ * stable/unstable token split — including "recall" corrections when later text
+ * changes how earlier text should be coloured. One tokenizer per block keeps its
+ * grammar state isolated (a shared highlighter tokenized directly is order-
+ * dependent across blocks); enqueue is async, so calls are chained to stay in
+ * order. Newlines live inside token content, so the flat span list lays out
+ * correctly under `white-space: pre`.
  */
 export function CodeBlock({ code, lang }: { code: string; lang: string }): React.JSX.Element {
   const dark = useThemeStore((s) => s.resolvedTheme === 'dark');
   const Icon = LANG_ICONS[lang] ?? FileCode;
+  const langId = resolveLang(lang);
+  const theme = dark ? DARK_THEME : LIGHT_THEME;
+
+  const [tokens, setTokens] = useState<ThemedToken[]>([]);
+  const stream = useRef<{
+    tokenizer: ShikiStreamTokenizer;
+    fed: string;
+    key: string;
+    chain: Promise<void>;
+  } | null>(null);
+
+  useEffect(() => {
+    const key = `${langId}|${theme}`;
+    let s = stream.current;
+    // Rebuild on a language/theme change or when `code` isn't an append of what
+    // we've fed (an edit, or a reused component now showing a different block).
+    if (!s || s.key !== key || !code.startsWith(s.fed)) {
+      s = stream.current = {
+        tokenizer: new ShikiStreamTokenizer({ highlighter, lang: langId, theme }),
+        fed: '',
+        key,
+        chain: Promise.resolve(),
+      };
+      setTokens([]);
+    }
+    const delta = code.slice(s.fed.length);
+    s.fed = code;
+    if (!delta) return;
+    const tk = s.tokenizer;
+    s.chain = s.chain.then(async () => {
+      await tk.enqueue(delta);
+      // A theme/lang change may have swapped the tokenizer while awaiting — only
+      // the current one publishes.
+      if (stream.current?.tokenizer === tk) setTokens([...tk.tokensStable, ...tk.tokensUnstable]);
+    });
+  }, [code, langId, theme]);
 
   return (
     <div className="my-3 overflow-hidden rounded-lg border border-border-default">
@@ -82,21 +129,16 @@ export function CodeBlock({ code, lang }: { code: string; lang: string }): React
         </span>
         <CopyButton text={code} />
       </div>
-      <Highlight code={code} language={lang} theme={dark ? themes.vsDark : themes.github}>
-        {({ tokens, getLineProps, getTokenProps }) => (
-          <pre className="overflow-x-auto bg-code-bg p-4 font-mono text-sm leading-relaxed">
-            {tokens.map((line, i) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: lines have no stable id
-              <div key={i} {...getLineProps({ line })}>
-                {line.map((token, k) => (
-                  // biome-ignore lint/suspicious/noArrayIndexKey: tokens have no stable id
-                  <span key={k} {...getTokenProps({ token })} />
-                ))}
-              </div>
-            ))}
-          </pre>
-        )}
-      </Highlight>
+      <pre className="overflow-x-auto bg-code-bg p-4 font-mono text-sm leading-relaxed">
+        <code>
+          {tokens.map((token, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: token stream has no stable id
+            <span key={i} style={token.htmlStyle ?? getTokenStyleObject(token)}>
+              {token.content}
+            </span>
+          ))}
+        </code>
+      </pre>
     </div>
   );
 }

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -401,6 +401,9 @@ export const en: typeof zh = {
       fontSizeSmall: 'Small',
       fontSizeDefault: 'Default',
       fontSizeLarge: 'Large',
+      codeGroup: 'Code theme',
+      codeThemeLight: 'Light theme',
+      codeThemeDark: 'Dark theme',
     },
     about: {
       description:

--- a/src/renderer/src/i18n/zh.ts
+++ b/src/renderer/src/i18n/zh.ts
@@ -400,6 +400,9 @@ export const zh = {
       fontSizeSmall: '小',
       fontSizeDefault: '默认',
       fontSizeLarge: '大',
+      codeGroup: '代码主题',
+      codeThemeLight: '浅色主题',
+      codeThemeDark: '深色主题',
     },
     about: {
       description:

--- a/src/renderer/src/lib/code-highlighter.test.ts
+++ b/src/renderer/src/lib/code-highlighter.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from 'bun:test';
+import { ShikiStreamTokenizer } from '@shikijs/stream';
+import { DARK_THEME, highlighter } from './code-highlighter';
+
+const sig = (tokens: { content: string; color?: string }[]) =>
+  tokens.map((t) => `${t.content} ${t.color ?? ''}`);
+const reconstruct = (tokens: { content: string }[]) => tokens.map((t) => t.content).join('');
+
+const CODE_A = 'function greet(name: string) {\n  /* c\n  */ return name;\n}';
+// biome-ignore lint/suspicious/noTemplateCurlyInString: sample code containing a template literal
+const CODE_B = 'const xs = [1, 2, 3].map((n) => `${n}`);';
+
+// What the component renders: the accumulated stable list plus the still-live
+// unstable tail (recalls are already reflected in these two arrays).
+const rendered = (tk: ShikiStreamTokenizer) => [...tk.tokensStable, ...tk.tokensUnstable];
+
+async function streamAll(code: string, chunk = 4): Promise<ShikiStreamTokenizer> {
+  const tk = new ShikiStreamTokenizer({ highlighter, lang: 'typescript', theme: DARK_THEME });
+  for (let i = 0; i < code.length; i += chunk) await tk.enqueue(code.slice(i, i + chunk));
+  return tk;
+}
+
+test('streamed tokens reconstruct the original source exactly (newlines and all)', async () => {
+  expect(reconstruct(rendered(await streamAll(CODE_A)))).toBe(CODE_A);
+});
+
+test('a tokenizer is unaffected by other blocks tokenizing on the shared highlighter', async () => {
+  const solo = sig(rendered(await streamAll(CODE_A)));
+
+  // Interleave CODE_A with CODE_B chunk-by-chunk across two tokenizers that
+  // share the one highlighter — the exact pattern that made a hand-rolled
+  // grammar-state cache non-deterministic.
+  const a = new ShikiStreamTokenizer({ highlighter, lang: 'typescript', theme: DARK_THEME });
+  const b = new ShikiStreamTokenizer({ highlighter, lang: 'typescript', theme: DARK_THEME });
+  for (let i = 0; i < Math.max(CODE_A.length, CODE_B.length); i += 4) {
+    if (i < CODE_A.length) await a.enqueue(CODE_A.slice(i, i + 4));
+    if (i < CODE_B.length) await b.enqueue(CODE_B.slice(i, i + 4));
+  }
+  expect(sig(rendered(a))).toEqual(solo);
+});
+
+test('chunk boundaries do not change the result (char-by-char == whole)', async () => {
+  const perChar = sig(rendered(await streamAll(CODE_A, 1)));
+  const whole = sig(rendered(await streamAll(CODE_A, CODE_A.length)));
+  expect(perChar).toEqual(whole);
+});

--- a/src/renderer/src/lib/code-highlighter.ts
+++ b/src/renderer/src/lib/code-highlighter.ts
@@ -26,8 +26,21 @@ import tsx from '@shikijs/langs/tsx';
 import typescript from '@shikijs/langs/typescript';
 import xml from '@shikijs/langs/xml';
 import yaml from '@shikijs/langs/yaml';
+import catppuccinLatte from '@shikijs/themes/catppuccin-latte';
+import catppuccinMocha from '@shikijs/themes/catppuccin-mocha';
 import darkPlus from '@shikijs/themes/dark-plus';
+import dracula from '@shikijs/themes/dracula';
+import githubDark from '@shikijs/themes/github-dark';
 import githubLight from '@shikijs/themes/github-light';
+import minLight from '@shikijs/themes/min-light';
+import nord from '@shikijs/themes/nord';
+import oneDarkPro from '@shikijs/themes/one-dark-pro';
+import oneLight from '@shikijs/themes/one-light';
+import rosePineDawn from '@shikijs/themes/rose-pine-dawn';
+import solarizedLight from '@shikijs/themes/solarized-light';
+import tokyoNight from '@shikijs/themes/tokyo-night';
+import vitesseDark from '@shikijs/themes/vitesse-dark';
+import vitesseLight from '@shikijs/themes/vitesse-light';
 import { createHighlighterCoreSync } from 'shiki/core';
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
 
@@ -48,7 +61,24 @@ export const highlighter = createHighlighterCoreSync({
   // forgiving: skip a grammar regex the JS engine can't translate instead of
   // throwing mid-render — a rare token loses color, the block still renders.
   engine: createJavaScriptRegexEngine({ forgiving: true }),
-  themes: [githubLight, darkPlus],
+  // Curated set matching CODE_THEMES_LIGHT / CODE_THEMES_DARK in shared/settings.
+  themes: [
+    githubLight,
+    oneLight,
+    vitesseLight,
+    catppuccinLatte,
+    minLight,
+    solarizedLight,
+    rosePineDawn,
+    darkPlus,
+    githubDark,
+    oneDarkPro,
+    dracula,
+    nord,
+    vitesseDark,
+    tokyoNight,
+    catppuccinMocha,
+  ],
   langs: [
     typescript,
     javascript,

--- a/src/renderer/src/lib/code-highlighter.ts
+++ b/src/renderer/src/lib/code-highlighter.ts
@@ -1,0 +1,89 @@
+import bash from '@shikijs/langs/bash';
+import c from '@shikijs/langs/c';
+import cpp from '@shikijs/langs/cpp';
+import css from '@shikijs/langs/css';
+import diff from '@shikijs/langs/diff';
+import docker from '@shikijs/langs/docker';
+import go from '@shikijs/langs/go';
+import graphql from '@shikijs/langs/graphql';
+import html from '@shikijs/langs/html';
+import java from '@shikijs/langs/java';
+import javascript from '@shikijs/langs/javascript';
+import json from '@shikijs/langs/json';
+import jsonc from '@shikijs/langs/jsonc';
+import jsx from '@shikijs/langs/jsx';
+import kotlin from '@shikijs/langs/kotlin';
+import markdown from '@shikijs/langs/markdown';
+import php from '@shikijs/langs/php';
+import python from '@shikijs/langs/python';
+import ruby from '@shikijs/langs/ruby';
+import rust from '@shikijs/langs/rust';
+import scss from '@shikijs/langs/scss';
+import sql from '@shikijs/langs/sql';
+import swift from '@shikijs/langs/swift';
+import toml from '@shikijs/langs/toml';
+import tsx from '@shikijs/langs/tsx';
+import typescript from '@shikijs/langs/typescript';
+import xml from '@shikijs/langs/xml';
+import yaml from '@shikijs/langs/yaml';
+import darkPlus from '@shikijs/themes/dark-plus';
+import githubLight from '@shikijs/themes/github-light';
+import { createHighlighterCoreSync } from 'shiki/core';
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
+
+/**
+ * One synchronous Shiki highlighter for the whole renderer. Built with the JS
+ * RegExp engine + a curated, fine-grained set of languages/themes so the module
+ * is created *synchronously* at import — no async load, no first-paint flash,
+ * and no wasm. `codeToTokens` is then a plain sync call, streaming-friendly.
+ *
+ * Languages outside this set fall back to plaintext (see resolveLang). Adding
+ * one is a two-line import here; a lazy on-demand loader can come later if the
+ * long tail matters.
+ */
+export const LIGHT_THEME = 'github-light';
+export const DARK_THEME = 'dark-plus';
+
+export const highlighter = createHighlighterCoreSync({
+  // forgiving: skip a grammar regex the JS engine can't translate instead of
+  // throwing mid-render — a rare token loses color, the block still renders.
+  engine: createJavaScriptRegexEngine({ forgiving: true }),
+  themes: [githubLight, darkPlus],
+  langs: [
+    typescript,
+    javascript,
+    jsx,
+    tsx,
+    python,
+    css,
+    scss,
+    html,
+    json,
+    jsonc,
+    bash,
+    rust,
+    go,
+    ruby,
+    php,
+    markdown,
+    yaml,
+    c,
+    cpp,
+    graphql,
+    swift,
+    kotlin,
+    docker,
+    java,
+    sql,
+    toml,
+    diff,
+    xml,
+  ],
+});
+
+const loaded = new Set(highlighter.getLoadedLanguages());
+
+/** Map a fence's language id (or alias) to a loaded grammar, else plaintext. */
+export function resolveLang(lang: string): string {
+  return loaded.has(lang) ? lang : 'text';
+}

--- a/src/renderer/src/routes/settings/$section.tsx
+++ b/src/renderer/src/routes/settings/$section.tsx
@@ -1,9 +1,18 @@
-import type { ComposerSendKey, UiFontSize } from '@shared/settings';
+import {
+  CODE_THEMES_DARK,
+  CODE_THEMES_LIGHT,
+  type CodeThemeDark,
+  type CodeThemeLight,
+  type ComposerSendKey,
+  type UiFontSize,
+} from '@shared/settings';
 import type { UpdaterStage } from '@shared/update';
 import { createFileRoute, notFound } from '@tanstack/react-router';
 import type { ParseKeys } from 'i18next';
 import { ArrowUpRight, Check, MessageSquare, Monitor, Moon, Sun } from 'lucide-react';
+import { useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+import { getTokenStyleObject } from 'shiki';
 import { Select } from '../../components/Select';
 import { ArchivedSection } from '../../components/settings/archived/ArchivedSection';
 import { IdentitySection } from '../../components/settings/identity/IdentitySection';
@@ -16,6 +25,7 @@ import { ProvidersSection } from '../../components/settings/providers/ProvidersS
 import { SkillsSection } from '../../components/settings/skills/SkillsSection';
 import { SubagentsSection } from '../../components/settings/subagents/SubagentsSection';
 import { UsageSection } from '../../components/settings/usage/UsageSection';
+import { highlighter } from '../../lib/code-highlighter';
 import { trpc } from '../../lib/trpc';
 import { type LanguagePref, useLanguage } from '../../lib/use-language';
 import { useSetting } from '../../lib/use-setting';
@@ -233,12 +243,64 @@ function GeneralSection(): React.JSX.Element {
   );
 }
 
+/** Shiki theme id → display label, e.g. `one-dark-pro` → `One Dark Pro`. */
+const prettyTheme = (id: string): string =>
+  id.replace(/(^|-)([a-z])/g, (_, sep, ch) => (sep ? ' ' : '') + ch.toUpperCase()).trim();
+
+const LIGHT_THEME_OPTIONS: ReadonlyArray<{ value: CodeThemeLight; label: string }> =
+  CODE_THEMES_LIGHT.map((v) => ({ value: v, label: prettyTheme(v) }));
+const DARK_THEME_OPTIONS: ReadonlyArray<{ value: CodeThemeDark; label: string }> =
+  CODE_THEMES_DARK.map((v) => ({ value: v, label: prettyTheme(v) }));
+
+const PREVIEW_CODE = `interface Config {
+  name: string; // workspace label
+  accent: string;
+}
+const theme: Config = { name: "atrium", accent: "#2383E2" };
+export const enabled = true;`;
+
+/** Renders the fixed snippet in a specific Shiki theme, using that theme's own
+ *  background/foreground — so a code theme can be judged before it's applied. */
+function ThemePreview({ theme }: { theme: string }): React.JSX.Element {
+  const { tokens, bg, fg } = useMemo(
+    () => highlighter.codeToTokens(PREVIEW_CODE, { lang: 'typescript', theme }),
+    [theme],
+  );
+  return (
+    <div
+      className="overflow-hidden rounded-lg border border-border-default text-xs leading-relaxed"
+      style={{ background: bg, color: fg }}
+    >
+      <pre className="overflow-x-auto p-3 font-mono">
+        {tokens.map((line, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: preview lines have no stable id
+          <div key={i} className="flex">
+            <span className="mr-3 w-4 shrink-0 select-none text-right tabular-nums opacity-40">
+              {i + 1}
+            </span>
+            <span className="whitespace-pre">
+              {line.map((tk, k) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: preview tokens have no stable id
+                <span key={k} style={getTokenStyleObject(tk)}>
+                  {tk.content}
+                </span>
+              ))}
+            </span>
+          </div>
+        ))}
+      </pre>
+    </div>
+  );
+}
+
 function AppearanceSection(): React.JSX.Element {
   const { t } = useTranslation();
   const theme = useThemeStore((s) => s.theme);
   const setTheme = useThemeStore((s) => s.setTheme);
   const { value: uiFont, set: setUiFont } = useSetting('appearance.uiFont');
   const { value: uiFontSize, set: setUiFontSize } = useSetting('appearance.uiFontSize');
+  const { value: codeThemeLight, set: setCodeThemeLight } = useSetting('appearance.codeThemeLight');
+  const { value: codeThemeDark, set: setCodeThemeDark } = useSetting('appearance.codeThemeDark');
 
   const tiles: Array<{ value: Theme; label: string; desc: string; icon: typeof Sun }> = [
     { value: 'light', label: 'Light', desc: t('settings.appearance.lightDesc'), icon: Sun },
@@ -321,6 +383,40 @@ function AppearanceSection(): React.JSX.Element {
           }
         />
       </SettingGroup>
+
+      <section>
+        <h2 className="mb-3 font-medium text-fg-primary text-sm">
+          {t('settings.appearance.codeGroup')}
+        </h2>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="flex min-w-0 flex-col gap-2">
+            <span className="font-medium text-fg-secondary text-xs">
+              {t('settings.appearance.codeThemeLight')}
+            </span>
+            <Select
+              value={codeThemeLight}
+              onChange={setCodeThemeLight}
+              options={LIGHT_THEME_OPTIONS}
+              aria-label={t('settings.appearance.codeThemeLight')}
+              className="w-full"
+            />
+            <ThemePreview theme={codeThemeLight} />
+          </div>
+          <div className="flex min-w-0 flex-col gap-2">
+            <span className="font-medium text-fg-secondary text-xs">
+              {t('settings.appearance.codeThemeDark')}
+            </span>
+            <Select
+              value={codeThemeDark}
+              onChange={setCodeThemeDark}
+              options={DARK_THEME_OPTIONS}
+              aria-label={t('settings.appearance.codeThemeDark')}
+              className="w-full"
+            />
+            <ThemePreview theme={codeThemeDark} />
+          </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -30,6 +30,31 @@ export type ComposerSendKey = (typeof COMPOSER_SEND_KEYS)[number];
 export const UI_FONT_SIZES = ['small', 'default', 'large'] as const;
 export type UiFontSize = (typeof UI_FONT_SIZES)[number];
 
+/** Curated Shiki syntax themes offered for code blocks, split by the app's
+ *  light/dark mode. Ids must stay in sync with the themes loaded by the
+ *  renderer's Shiki highlighter (src/renderer/.../code-highlighter.ts). */
+export const CODE_THEMES_LIGHT = [
+  'github-light',
+  'one-light',
+  'vitesse-light',
+  'catppuccin-latte',
+  'min-light',
+  'solarized-light',
+  'rose-pine-dawn',
+] as const;
+export const CODE_THEMES_DARK = [
+  'dark-plus',
+  'github-dark',
+  'one-dark-pro',
+  'dracula',
+  'nord',
+  'vitesse-dark',
+  'tokyo-night',
+  'catppuccin-mocha',
+] as const;
+export type CodeThemeLight = (typeof CODE_THEMES_LIGHT)[number];
+export type CodeThemeDark = (typeof CODE_THEMES_DARK)[number];
+
 const generalShape = z.object({
   /** UI language; 'system' follows the OS locale. */
   language: z.enum(['system', 'en', 'zh']).default('system'),
@@ -60,6 +85,10 @@ const appearanceShape = z.object({
   /** Global text-size step; multiplies the whole type scale so app chrome, chat
    *  text, and code resize together. */
   uiFontSize: z.enum(UI_FONT_SIZES).default('default'),
+  /** Shiki syntax theme for code blocks in light mode. */
+  codeThemeLight: z.enum(CODE_THEMES_LIGHT).default('github-light'),
+  /** Shiki syntax theme for code blocks in dark mode. */
+  codeThemeDark: z.enum(CODE_THEMES_DARK).default('dark-plus'),
 });
 
 const keyboardShape = z.object({


### PR DESCRIPTION
The "code rendering" foundation plus the user-facing code-theme setting. Draft until code theme lands.

## Done
- **Shiki migration** (`refactor(chat)`): replaces prism-react-renderer with Shiki (VS Code TextMate grammars) + `@shikijs/stream` for streaming. Uses Shiki's JS RegExp engine (the renderer CSP forbids the WASM engine's `unsafe-eval`); one `ShikiStreamTokenizer` per block keeps grammar state deterministic across interleaved blocks (covered by a test). Editor-accurate highlighting, and one theme system for what comes next.

## In progress (before merge)
- **Code theme setting** — expose Shiki's themes in Settings → Appearance so the syntax theme is user-configurable (the appearance feature deferred earlier).

## Out of scope (separate work later)
- Artifact-panel diff review via `@git-diff-view/shiki`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)