### PR TITLE
docs: require squash-merge for PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,3 +20,8 @@
 - **Angular Conventional Commits** format: `type(scope): subject` (e.g. `feat(chat): stream tool calls`). Types: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`, `perf`, `build`, `ci`. Scope is the area touched (`chat`, `tools`, `agent`, `db`…); omit it if the change is cross-cutting. Subject is imperative and lowercase.
 - Describe what the change does in plain functional terms; **never** include project-internal numbering (Step 1.1, D8, V0, Phase…). Reference a design by its semantic name ("empty state"), not its D-number.
 - Commit cadence: each reviewed sub-task → commit before the next; don't batch a whole step into one big diff.
+
+## Pull requests
+
+- **Squash-merge only.** A PR lands on `main` as exactly **one** commit, so the release-please changelog shows a single entry per PR. The branch may carry many small per-step commits for review — squashing collapses them. Never rebase-merge or merge-commit a PR. The repo is configured to allow squash only (the other buttons are disabled). The squash commit's subject is the **PR title**, so write the PR title as a clean `type(scope): subject` conventional commit — that's what release-please reads.
+- Merge via `gh pr merge <n> --squash` (add `--auto` after `gh pr ready` to land on green CI).


### PR DESCRIPTION
Records the squash-merge convention in CLAUDE.md, and the repo is now configured to allow squash only (rebase / merge-commit disabled) with the squash subject forced to the PR title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)