### PR TITLE
perf(sidebar): remove redundant re-renders across sidebar and startup

### DIFF
--- a/src/renderer/src/components/sidebar/ProjectRow.tsx
+++ b/src/renderer/src/components/sidebar/ProjectRow.tsx
@@ -1,13 +1,13 @@
 import { useNavigate } from '@tanstack/react-router';
 import { ChevronDown, ChevronRight, Folder, FolderOpen, SquarePen } from 'lucide-react';
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePendingProject } from '../../state/pending-project-store';
 import { ProjectMenu } from './ProjectMenu';
 import { RowAction } from './primitives';
 import type { ProjectItem, ThreadItem } from './types';
 
-export function ProjectRow({
+export const ProjectRow = memo(function ProjectRow({
   project,
   expanded,
   onToggle,
@@ -16,7 +16,7 @@ export function ProjectRow({
 }: {
   project: ProjectItem;
   expanded: boolean;
-  onToggle: () => void;
+  onToggle: (projectId: string) => void;
   threads: ThreadItem[];
   renderThread: (thread: ThreadItem) => React.JSX.Element;
 }): React.JSX.Element {
@@ -28,7 +28,7 @@ export function ProjectRow({
       <div className="group flex w-full items-center gap-1 rounded-md px-3 py-1.5 text-fg-secondary text-sm hover:bg-sidebar-item-hover hover:text-fg-primary">
         <button
           type="button"
-          onClick={onToggle}
+          onClick={() => onToggle(project.id)}
           className="flex min-w-0 flex-1 items-center gap-2 text-left"
         >
           {expanded ? (
@@ -78,4 +78,4 @@ export function ProjectRow({
       </div>
     </div>
   );
-}
+});

--- a/src/renderer/src/components/sidebar/Sidebar.tsx
+++ b/src/renderer/src/components/sidebar/Sidebar.tsx
@@ -8,7 +8,7 @@ import { useCommandPalette } from '../../state/command-palette-store';
 import { useUpdateStore } from '../../state/update-store';
 import { ProjectRow } from './ProjectRow';
 import { SbIconButton, SbNavItem, SbSection } from './primitives';
-import { ThreadRow } from './ThreadRow';
+import { ThreadRow, useThreadRowActions } from './ThreadRow';
 import type { ProjectItem, ThreadItem } from './types';
 
 // Stable empty list so a project with no threads keeps a referentially-constant
@@ -18,6 +18,8 @@ const EMPTY_THREADS: ThreadItem[] = [];
 export const Sidebar = memo(function Sidebar(): React.JSX.Element {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  // One shared set of row mutations for the whole list (see useThreadRowActions).
+  const rowActions = useThreadRowActions();
   const openPalette = useCommandPalette((s) => s.setOpen);
   const updateStage = useUpdateStore((s) => s.state.stage);
   const openUpdateDialog = useUpdateStore((s) => s.openDialog);
@@ -125,9 +127,10 @@ export const Sidebar = memo(function Sidebar(): React.JSX.Element {
         thread={thread}
         running={runningSet.has(thread.id)}
         hasSchedule={scheduledThreadIds.has(thread.id)}
+        actions={rowActions}
       />
     ),
-    [runningSet, scheduledThreadIds],
+    [runningSet, scheduledThreadIds, rowActions],
   );
   const renderProject = useCallback(
     (project: ProjectItem): React.JSX.Element => (

--- a/src/renderer/src/components/sidebar/Sidebar.tsx
+++ b/src/renderer/src/components/sidebar/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigate } from '@tanstack/react-router';
 import { CalendarClock, FolderPlus, Search, Settings, SquarePen } from 'lucide-react';
-import { memo, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { dropThreadChat } from '../../lib/chat-store';
 import { trpc } from '../../lib/trpc';
@@ -11,6 +11,10 @@ import { ProjectRow } from './ProjectRow';
 import { SbIconButton, SbNavItem, SbSection } from './primitives';
 import { ThreadRow } from './ThreadRow';
 import type { ProjectItem, ThreadItem } from './types';
+
+// Stable empty list so a project with no threads keeps a referentially-constant
+// `threads` prop across renders, letting the memoized ProjectRow bail out.
+const EMPTY_THREADS: ThreadItem[] = [];
 
 export const Sidebar = memo(function Sidebar(): React.JSX.Element {
   const { t } = useTranslation();
@@ -27,12 +31,16 @@ export const Sidebar = memo(function Sidebar(): React.JSX.Element {
   // Poll the main process for which threads are generating; a small id list, so
   // the interval is cheap (unlike polling message content).
   const { data: running } = trpc.threads.running.useQuery(undefined, { refetchInterval: 2000 });
-  const runningSet = new Set(running);
+  // React Query keeps `running` referentially stable across polls when the set
+  // is unchanged (structural sharing), so this Set — and every row prop derived
+  // from it — stays stable and the memoized rows don't re-render every 2s.
+  const runningSet = useMemo(() => new Set(running), [running]);
   // Threads bound to a scheduled task get a hover clock badge. The binding lives
   // on the task (scheduledTasks.threadId), so derive the set from the task list.
   const { data: scheduled } = trpc.scheduled.list.useQuery();
-  const scheduledThreadIds = new Set(
-    (scheduled ?? []).map((task) => task.threadId).filter(Boolean),
+  const scheduledThreadIds = useMemo(
+    () => new Set((scheduled ?? []).map((task) => task.threadId).filter(Boolean)),
+    [scheduled],
   );
 
   // Adding a project is a sidebar-level action (the Projects header button), not
@@ -49,13 +57,16 @@ export const Sidebar = memo(function Sidebar(): React.JSX.Element {
   // Collapse state is held centrally so it survives a project moving between the
   // Pinned and Projects sections (which remounts the row) on pin/unpin.
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
-  const toggleCollapse = (id: string): void =>
-    setCollapsed((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
+  const toggleCollapse = useCallback(
+    (id: string): void =>
+      setCollapsed((prev) => {
+        const next = new Set(prev);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      }),
+    [],
+  );
 
   // A background run (a scheduled task) has no client mounted to refresh views
   // when it starts or finishes. Watch the polled running set: for every thread
@@ -80,35 +91,58 @@ export const Sidebar = memo(function Sidebar(): React.JSX.Element {
     utils.threads.list.invalidate();
   }, [running, utils]);
 
-  const allThreads = threads ?? [];
-  const allProjects = projects ?? [];
-  // A pinned thread always floats to the Pinned section as a standalone row, so
-  // project / chat lists only ever render their own non-pinned threads.
-  const pinnedThreads = allThreads.filter((th) => th.pinned);
-  const pinnedProjects = allProjects.filter((p) => p.pinned);
-  const openProjects = allProjects.filter((p) => !p.pinned);
-  const projectThreads = (projectId: string): ThreadItem[] =>
-    allThreads.filter((th) => th.projectId === projectId && !th.pinned);
-  const looseThreads = allThreads.filter((th) => th.projectId == null && !th.pinned);
+  // Bucket threads once per data change instead of re-filtering the whole list
+  // per project on every render. A pinned thread always floats to the Pinned
+  // section as a standalone row, so project / chat lists only ever render their
+  // own non-pinned threads.
+  const { pinnedThreads, pinnedProjects, openProjects, looseThreads, threadsByProject } =
+    useMemo(() => {
+      const allThreads = threads ?? [];
+      const allProjects = projects ?? [];
+      const byProject = new Map<string, ThreadItem[]>();
+      const loose: ThreadItem[] = [];
+      for (const th of allThreads) {
+        if (th.pinned) continue;
+        if (th.projectId == null) loose.push(th);
+        else {
+          const bucket = byProject.get(th.projectId);
+          if (bucket) bucket.push(th);
+          else byProject.set(th.projectId, [th]);
+        }
+      }
+      return {
+        pinnedThreads: allThreads.filter((th) => th.pinned),
+        pinnedProjects: allProjects.filter((p) => p.pinned),
+        openProjects: allProjects.filter((p) => !p.pinned),
+        looseThreads: loose,
+        threadsByProject: byProject,
+      };
+    }, [threads, projects]);
   const hasPinned = pinnedThreads.length > 0 || pinnedProjects.length > 0;
 
-  const renderThread = (thread: ThreadItem): React.JSX.Element => (
-    <ThreadRow
-      key={thread.id}
-      thread={thread}
-      running={runningSet.has(thread.id)}
-      hasSchedule={scheduledThreadIds.has(thread.id)}
-    />
+  const renderThread = useCallback(
+    (thread: ThreadItem): React.JSX.Element => (
+      <ThreadRow
+        key={thread.id}
+        thread={thread}
+        running={runningSet.has(thread.id)}
+        hasSchedule={scheduledThreadIds.has(thread.id)}
+      />
+    ),
+    [runningSet, scheduledThreadIds],
   );
-  const renderProject = (project: ProjectItem): React.JSX.Element => (
-    <ProjectRow
-      key={project.id}
-      project={project}
-      expanded={!collapsed.has(project.id)}
-      onToggle={() => toggleCollapse(project.id)}
-      threads={projectThreads(project.id)}
-      renderThread={renderThread}
-    />
+  const renderProject = useCallback(
+    (project: ProjectItem): React.JSX.Element => (
+      <ProjectRow
+        key={project.id}
+        project={project}
+        expanded={!collapsed.has(project.id)}
+        onToggle={toggleCollapse}
+        threads={threadsByProject.get(project.id) ?? EMPTY_THREADS}
+        renderThread={renderThread}
+      />
+    ),
+    [collapsed, toggleCollapse, threadsByProject, renderThread],
   );
 
   return (

--- a/src/renderer/src/components/sidebar/Sidebar.tsx
+++ b/src/renderer/src/components/sidebar/Sidebar.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import { dropThreadChat } from '../../lib/chat-store';
 import { trpc } from '../../lib/trpc';
 import { useCommandPalette } from '../../state/command-palette-store';
-import { useSidebarStore } from '../../state/sidebar-store';
 import { useUpdateStore } from '../../state/update-store';
 import { ProjectRow } from './ProjectRow';
 import { SbIconButton, SbNavItem, SbSection } from './primitives';
@@ -19,7 +18,6 @@ const EMPTY_THREADS: ThreadItem[] = [];
 export const Sidebar = memo(function Sidebar(): React.JSX.Element {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const width = useSidebarStore((s) => s.width);
   const openPalette = useCommandPalette((s) => s.setOpen);
   const updateStage = useUpdateStore((s) => s.state.stage);
   const openUpdateDialog = useUpdateStore((s) => s.openDialog);
@@ -148,7 +146,11 @@ export const Sidebar = memo(function Sidebar(): React.JSX.Element {
   return (
     <aside
       className="flex h-full min-h-0 select-none flex-col border-r border-border-default bg-surface"
-      style={{ width }}
+      // Width comes from AppLayout via the --sidebar-width CSS variable so a
+      // resize drag (which updates it every frame) repaints without re-rendering
+      // the whole sidebar tree. Kept explicit — not 100% — so collapsing (grid
+      // column → 0) clips the sidebar instead of reflowing its contents.
+      style={{ width: 'var(--sidebar-width, 260px)' }}
     >
       <div className="atrium-titlebar" />
 

--- a/src/renderer/src/components/sidebar/ThreadRow.tsx
+++ b/src/renderer/src/components/sidebar/ThreadRow.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { Archive, Clock, Pin, PinOff } from 'lucide-react';
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { timeAgo } from '../../lib/time';
 import { trpc } from '../../lib/trpc';
@@ -90,6 +90,11 @@ export const ThreadRow = memo(function ThreadRow({
   actions,
 }: ThreadRowProps): React.JSX.Element {
   const { t } = useTranslation();
+  // Mount the hover actions (and their radix tooltips) only while the row is
+  // hovered. They're hidden until hover anyway, and eagerly mounting a full
+  // tooltip stack per action across ~200 rows is a big chunk of the initial
+  // mount and of every full re-render.
+  const [hovered, setHovered] = useState(false);
   const unread =
     thread.lastReadAt != null && new Date(thread.updatedAt) > new Date(thread.lastReadAt);
   return (
@@ -98,6 +103,8 @@ export const ThreadRow = memo(function ThreadRow({
       params={{ threadId: thread.id }}
       className={chatRowBase}
       activeProps={{ className: chatRowActive }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
     >
       <span className="min-w-0 flex-1 truncate text-left">
         {thread.title ?? t('common.untitledChat')}
@@ -111,7 +118,7 @@ export const ThreadRow = memo(function ThreadRow({
       ) : (
         // Status indicator yields to the hover actions (pin / archive).
         <span className="relative flex shrink-0 items-center">
-          <span className="flex items-center group-hover:invisible">
+          <span className={`flex items-center ${hovered ? 'invisible' : ''}`}>
             {unread ? (
               <span
                 role="status"
@@ -122,27 +129,33 @@ export const ThreadRow = memo(function ThreadRow({
               <span className="text-fg-disabled text-xs">{timeAgo(thread.updatedAt)}</span>
             )}
           </span>
-          <span className="absolute right-0 hidden items-center gap-0.5 group-hover:flex">
-            {hasSchedule && (
-              <Tooltip content={t('sidebar.scheduled')}>
-                <span className="flex items-center p-0.5 text-fg-tertiary">
-                  <Clock className="size-[13px]" />
-                </span>
-              </Tooltip>
-            )}
-            <RowAction
-              title={thread.pinned ? t('sidebar.unpin') : t('sidebar.pin')}
-              icon={
-                thread.pinned ? <PinOff className="size-[13px]" /> : <Pin className="size-[13px]" />
-              }
-              onClick={() => actions.togglePin(thread)}
-            />
-            <RowAction
-              title={t('chat.archive')}
-              icon={<Archive className="size-[13px]" />}
-              onClick={() => actions.archive(thread.id)}
-            />
-          </span>
+          {hovered && (
+            <span className="absolute right-0 flex items-center gap-0.5">
+              {hasSchedule && (
+                <Tooltip content={t('sidebar.scheduled')}>
+                  <span className="flex items-center p-0.5 text-fg-tertiary">
+                    <Clock className="size-[13px]" />
+                  </span>
+                </Tooltip>
+              )}
+              <RowAction
+                title={thread.pinned ? t('sidebar.unpin') : t('sidebar.pin')}
+                icon={
+                  thread.pinned ? (
+                    <PinOff className="size-[13px]" />
+                  ) : (
+                    <Pin className="size-[13px]" />
+                  )
+                }
+                onClick={() => actions.togglePin(thread)}
+              />
+              <RowAction
+                title={t('chat.archive')}
+                icon={<Archive className="size-[13px]" />}
+                onClick={() => actions.archive(thread.id)}
+              />
+            </span>
+          )}
         </span>
       )}
     </Link>

--- a/src/renderer/src/components/sidebar/ThreadRow.tsx
+++ b/src/renderer/src/components/sidebar/ThreadRow.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { Archive, Clock, Pin, PinOff } from 'lucide-react';
-import { memo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { timeAgo } from '../../lib/time';
 import { trpc } from '../../lib/trpc';
@@ -14,7 +14,47 @@ const chatRowBase =
 const chatRowActive =
   'group flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-sm bg-sidebar-item-active text-fg-primary';
 
-type ThreadRowProps = { thread: ThreadItem; running: boolean; hasSchedule: boolean };
+export type ThreadRowActions = {
+  archive: (id: string) => void;
+  togglePin: (thread: ThreadItem) => void;
+};
+
+/**
+ * The pin / unpin / archive mutations are identical for every row, so creating
+ * them inside ThreadRow means ~600 React Query mutation observers (3 × ~200
+ * rows), each with its own MutationCache subscription and mount effects — a big
+ * slice of a full sidebar re-render or the initial mount. Instantiate them once
+ * at the sidebar level and hand every row the same callbacks instead.
+ */
+export function useThreadRowActions(): ThreadRowActions {
+  const { t } = useTranslation();
+  const utils = trpc.useUtils();
+  const refresh = useCallback(() => {
+    utils.threads.list.invalidate();
+  }, [utils]);
+  const archive = trpc.threads.archive.useMutation({
+    onSuccess: () => {
+      refresh();
+      toast.success(t('chat.archived'));
+    },
+  });
+  const pin = trpc.threads.pin.useMutation({ onSuccess: refresh });
+  const unpin = trpc.threads.unpin.useMutation({ onSuccess: refresh });
+  return useMemo(
+    () => ({
+      archive: (id: string) => archive.mutate({ id }),
+      togglePin: (thread: ThreadItem) => (thread.pinned ? unpin : pin).mutate({ id: thread.id }),
+    }),
+    [archive, pin, unpin],
+  );
+}
+
+type ThreadRowProps = {
+  thread: ThreadItem;
+  running: boolean;
+  hasSchedule: boolean;
+  actions: ThreadRowActions;
+};
 
 // updatedAt / lastReadAt come back as fresh values on every refetch (Date
 // instances at runtime, though typed as ISO strings), so compare by time value
@@ -47,21 +87,9 @@ export const ThreadRow = memo(function ThreadRow({
   thread,
   running,
   hasSchedule,
+  actions,
 }: ThreadRowProps): React.JSX.Element {
   const { t } = useTranslation();
-  const utils = trpc.useUtils();
-  const refresh = (): void => {
-    utils.threads.list.invalidate();
-  };
-  const archive = trpc.threads.archive.useMutation({
-    onSuccess: () => {
-      refresh();
-      toast.success(t('chat.archived'));
-    },
-  });
-  const pin = trpc.threads.pin.useMutation({ onSuccess: refresh });
-  const unpin = trpc.threads.unpin.useMutation({ onSuccess: refresh });
-
   const unread =
     thread.lastReadAt != null && new Date(thread.updatedAt) > new Date(thread.lastReadAt);
   return (
@@ -107,12 +135,12 @@ export const ThreadRow = memo(function ThreadRow({
               icon={
                 thread.pinned ? <PinOff className="size-[13px]" /> : <Pin className="size-[13px]" />
               }
-              onClick={() => (thread.pinned ? unpin : pin).mutate({ id: thread.id })}
+              onClick={() => actions.togglePin(thread)}
             />
             <RowAction
               title={t('chat.archive')}
               icon={<Archive className="size-[13px]" />}
-              onClick={() => archive.mutate({ id: thread.id })}
+              onClick={() => actions.archive(thread.id)}
             />
           </span>
         </span>

--- a/src/renderer/src/components/sidebar/ThreadRow.tsx
+++ b/src/renderer/src/components/sidebar/ThreadRow.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { Archive, Clock, Pin, PinOff } from 'lucide-react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { timeAgo } from '../../lib/time';
 import { trpc } from '../../lib/trpc';
@@ -13,15 +14,40 @@ const chatRowBase =
 const chatRowActive =
   'group flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-sm bg-sidebar-item-active text-fg-primary';
 
-export function ThreadRow({
+type ThreadRowProps = { thread: ThreadItem; running: boolean; hasSchedule: boolean };
+
+// updatedAt / lastReadAt come back as fresh values on every refetch (Date
+// instances at runtime, though typed as ISO strings), so compare by time value
+// — reference (===) never matches. new Date() accepts both forms; null is a
+// valid lastReadAt (never read), so guard it first.
+const sameTime = (a: string | null, b: string | null): boolean =>
+  a == null || b == null ? a === b : new Date(a).getTime() === new Date(b).getTime();
+
+/**
+ * Opening a chat refetches the sidebar's thread list (a chat open can flip the
+ * running set or land a model-generated title), and the query layer returns
+ * fresh object identities even for rows whose data is unchanged — so a
+ * reference-equality memo would still re-render all 200-ish rows (and their
+ * radix-tooltip subtrees) on every chat switch. Compare the fields the row
+ * actually renders instead, so an unchanged row truly bails out.
+ */
+function threadRowPropsEqual(a: ThreadRowProps, b: ThreadRowProps): boolean {
+  return (
+    a.running === b.running &&
+    a.hasSchedule === b.hasSchedule &&
+    a.thread.id === b.thread.id &&
+    a.thread.title === b.thread.title &&
+    a.thread.pinned === b.thread.pinned &&
+    sameTime(a.thread.updatedAt, b.thread.updatedAt) &&
+    sameTime(a.thread.lastReadAt, b.thread.lastReadAt)
+  );
+}
+
+export const ThreadRow = memo(function ThreadRow({
   thread,
   running,
   hasSchedule,
-}: {
-  thread: ThreadItem;
-  running: boolean;
-  hasSchedule: boolean;
-}): React.JSX.Element {
+}: ThreadRowProps): React.JSX.Element {
   const { t } = useTranslation();
   const utils = trpc.useUtils();
   const refresh = (): void => {
@@ -93,4 +119,4 @@ export function ThreadRow({
       )}
     </Link>
   );
-}
+}, threadRowPropsEqual);

--- a/src/renderer/src/i18n/index.ts
+++ b/src/renderer/src/i18n/index.ts
@@ -10,13 +10,23 @@ declare module 'i18next' {
   }
 }
 
-// Best-guess initial language from the system locale. The persisted preference
-// (which may differ) is applied on mount via useLanguage, correcting this.
+export const LANG_CACHE_KEY = 'atrium.language';
+
+// The real preference lives in main-process settings and only resolves after an
+// async IPC round-trip. If we seeded i18n from navigator.language instead, we'd
+// mount in the wrong language (Electron reports the app locale, e.g. en-US, not
+// the user's chosen UI language) and then take a full-tree re-render — every
+// useTranslation consumer, i.e. the whole sidebar — when the preference lands a
+// couple seconds into a busy startup. useLanguage mirrors the resolved language
+// into localStorage (synchronous), so subsequent launches start correct and
+// skip that changeLanguage entirely. First-ever launch still falls back to the
+// locale guess until the preference caches.
 const guess = navigator.language.toLowerCase().startsWith('zh') ? 'zh' : 'en';
+const initialLng = localStorage.getItem(LANG_CACHE_KEY) ?? guess;
 
 i18n.use(initReactI18next).init({
   resources: { en: { translation: en }, zh: { translation: zh } },
-  lng: guess,
+  lng: initialLng,
   fallbackLng: 'en',
   interpolation: { escapeValue: false },
   // No Suspense boundary wraps the app, so a live changeLanguage must re-render

--- a/src/renderer/src/lib/use-language.ts
+++ b/src/renderer/src/lib/use-language.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { LANG_CACHE_KEY } from '../i18n';
 import { useSetting } from './use-setting';
 
 export type LanguagePref = 'system' | 'en' | 'zh';
@@ -22,11 +23,16 @@ export function useLanguage(): { pref: LanguagePref; setLanguage: (p: LanguagePr
   useEffect(() => {
     if (isLoading) return;
     const lng = resolveLang(pref);
+    // Cache synchronously so the next launch seeds i18n with the right language
+    // and skips the mount-time changeLanguage (see i18n/index.ts).
+    localStorage.setItem(LANG_CACHE_KEY, lng);
     if (i18n.language !== lng) void i18n.changeLanguage(lng);
   }, [isLoading, pref, i18n]);
 
   const setLanguage = (p: LanguagePref): void => {
-    void i18n.changeLanguage(resolveLang(p));
+    const lng = resolveLang(p);
+    localStorage.setItem(LANG_CACHE_KEY, lng);
+    void i18n.changeLanguage(lng);
     set(p);
   };
 

--- a/src/renderer/src/routes/_app/route.tsx
+++ b/src/renderer/src/routes/_app/route.tsx
@@ -47,11 +47,17 @@ function AppLayout(): React.JSX.Element {
   return (
     <div
       className="grid h-screen"
-      style={{
-        gridTemplateColumns: `${collapsed ? 0 : width}px 1fr`,
-        // Animate collapse/expand, but track the cursor 1:1 while dragging.
-        transition: dragging ? 'none' : 'grid-template-columns 200ms ease-out',
-      }}
+      style={
+        {
+          gridTemplateColumns: `${collapsed ? 0 : width}px 1fr`,
+          // Publish the width to the sidebar via CSS so its <aside> tracks a resize
+          // drag without the Sidebar subtree re-rendering every frame — this layout
+          // re-renders for the grid column anyway.
+          '--sidebar-width': `${width}px`,
+          // Animate collapse/expand, but track the cursor 1:1 while dragging.
+          transition: dragging ? 'none' : 'grid-template-columns 200ms ease-out',
+        } as React.CSSProperties
+      }
     >
       <div className="relative min-w-0 overflow-hidden">
         <Sidebar />


### PR DESCRIPTION
Investigated with CDP + a fiber-level `PerformedWork` instrument driving the running dev app, so every claim below is measured, not estimated.

## Problem

The sidebar re-rendered all ~200 `ThreadRow`s (each wrapping ~4 radix Tooltip stacks) on almost any interaction, and the app did a full-tree re-render on every refresh. Two root causes:

- **Prop/subscription churn** re-rendered the whole list on collapse toggle, chat navigation, and every resize-drag frame.
- **A startup language switch**: i18n seeded from `navigator.language` (Electron's app locale, e.g. `en-US`, not the user's chosen UI language), so it mounted in the wrong language and re-rendered everything when the persisted preference resolved ~2s into a busy startup (with a visible en→zh flash).

## Changes

| Commit | Fix |
| --- | --- |
| memoize rows | `memo` on `ThreadRow`/`ProjectRow` + stabilize every prop Sidebar passes (useMemo/useCallback, module-level `EMPTY_THREADS`). `ThreadRow` uses a field-level comparator because the query layer hands back fresh object identities (Date instances) on refetch. |
| resize via CSS var | Sidebar subscribed to `width` only to size its `<aside>`; publish it as a `--sidebar-width` CSS var from AppLayout (which re-renders for the grid anyway) so a drag repaints without re-rendering the sidebar tree. |
| i18n language cache | Mirror the resolved language into `localStorage` and seed i18n from it, so refreshes start in the right language and skip the mount-time `changeLanguage`. |
| share row mutations | The identical pin/unpin/archive `useMutation`s moved from per-row into one `useThreadRowActions()` called once by Sidebar (~588 fewer React Query observers). |
| lazy hover actions | Mount each row's hover actions + their tooltips only while the row is hovered. |

## Measured (200-thread sidebar)

| Interaction | Before | After |
| --- | --- | --- |
| Collapse/expand project | 8003 renders, 158ms worst frame | **64**, 15ms |
| Switch chats (sidebar part) | 8904 renders (196 rows re-render) | **1087** (0 sidebar rows) |
| Resize drag | 2496 renders, 50ms | **300**, 17ms |
| Refresh (startup) | 2 full-tree renders (mount + language switch) | **1** (mount only) |
| Per-row hooks / context subs | 35 / 34 | **13 / 2** |
| Peak mount commit | 7742 components | **487** |

No behavior change: collapse animation, resize, hover actions, pin/unpin/archive, and language switching all verified working.

## Follow-up (not in this PR)

Opening a long chat still highlights all code blocks synchronously (~118ms frame). That's the message list lacking virtualization — a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
