### PR TITLE
fix(mcp): keep form dialog actions visible and restore scrolling

### DIFF
--- a/src/renderer/src/components/settings/mcp/McpForm.tsx
+++ b/src/renderer/src/components/settings/mcp/McpForm.tsx
@@ -106,133 +106,136 @@ export function McpForm({ server, onDone, onCancel }: McpFormProps): React.JSX.E
   const valid = name.trim().length > 0 && (transport === 'stdio' ? command.trim() : url.trim());
 
   return (
-    <div className="flex h-full flex-col gap-4 overflow-y-auto p-6">
-      <div>
-        <span className={label}>{t('settings.mcp.name')}</span>
-        <input
-          className={input}
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder={t('settings.mcp.namePlaceholder')}
-        />
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
+        <div>
+          <span className={label}>{t('settings.mcp.name')}</span>
+          <input
+            className={input}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder={t('settings.mcp.namePlaceholder')}
+          />
+        </div>
+
+        <div className="flex rounded-lg border border-border-default p-0.5">
+          {(['stdio', 'http'] as const).map((tr) => (
+            <button
+              key={tr}
+              type="button"
+              onClick={() => setTransport(tr)}
+              className={`flex-1 rounded-md px-3 py-1.5 text-sm ${
+                transport === tr ? 'bg-surface-strong text-fg-primary' : 'text-fg-secondary'
+              }`}
+            >
+              {t(tr === 'stdio' ? 'settings.mcp.stdio' : 'settings.mcp.http')}
+            </button>
+          ))}
+        </div>
+
+        {transport === 'stdio' ? (
+          <>
+            <div>
+              <span className={label}>{t('settings.mcp.command')}</span>
+              <input
+                className={input}
+                value={command}
+                onChange={(e) => setCommand(e.target.value)}
+                placeholder="npx -y @scope/server"
+              />
+            </div>
+            <StrList
+              listLabel={t('settings.mcp.args')}
+              items={args}
+              onChange={setArgs}
+              addLabel={t('settings.mcp.addArg')}
+            />
+            <PairEditor
+              listLabel={t('settings.mcp.env')}
+              note={t('settings.mcp.envNote')}
+              items={env}
+              onChange={setEnv}
+              addLabel={t('settings.mcp.addEnv')}
+            />
+            <StrList
+              listLabel={t('settings.mcp.envPassthrough')}
+              note={t('settings.mcp.envPassthroughNote')}
+              items={envPassthrough}
+              onChange={setEnvPassthrough}
+              addLabel={t('settings.mcp.addVar')}
+            />
+            <div>
+              <span className={label}>{t('settings.mcp.cwd')}</span>
+              <input
+                className={input}
+                value={cwd}
+                onChange={(e) => setCwd(e.target.value)}
+                placeholder="~/code"
+              />
+            </div>
+          </>
+        ) : (
+          <>
+            <div>
+              <span className={label}>{t('settings.mcp.url')}</span>
+              <input
+                className={input}
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="https://mcp.example.com/mcp"
+              />
+            </div>
+            <div>
+              <span className={label}>{t('settings.mcp.bearerTokenEnvVar')}</span>
+              <input
+                className={input}
+                value={bearerTokenEnvVar}
+                onChange={(e) => setBearerTokenEnvVar(e.target.value)}
+                placeholder="MCP_BEARER_TOKEN"
+              />
+            </div>
+            <PairEditor
+              listLabel={t('settings.mcp.headers')}
+              note={t('settings.mcp.headersNote')}
+              items={headers}
+              onChange={setHeaders}
+              addLabel={t('settings.mcp.addHeader')}
+            />
+            <PairEditor
+              listLabel={t('settings.mcp.headersFromEnv')}
+              note={t('settings.mcp.headersFromEnvNote')}
+              items={headersFromEnv}
+              onChange={setHeadersFromEnv}
+              addLabel={t('settings.mcp.addVar')}
+            />
+          </>
+        )}
+
+        <label className="flex items-center gap-2 text-fg-secondary text-sm">
+          <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+          {t('settings.mcp.enabled')}
+        </label>
       </div>
 
-      <div className="flex rounded-lg border border-border-default p-0.5">
-        {(['stdio', 'http'] as const).map((tr) => (
+      <div className="shrink-0 border-border-default border-t px-6 py-3">
+        {error && <p className="mb-2 text-danger text-sm">{error}</p>}
+        <div className="flex items-center justify-end gap-2">
           <button
-            key={tr}
             type="button"
-            onClick={() => setTransport(tr)}
-            className={`flex-1 rounded-md px-3 py-1.5 text-sm ${
-              transport === tr ? 'bg-surface-strong text-fg-primary' : 'text-fg-secondary'
-            }`}
+            onClick={onCancel}
+            className="rounded-md px-3 py-1.5 text-fg-secondary text-sm hover:bg-elevated"
           >
-            {t(tr === 'stdio' ? 'settings.mcp.stdio' : 'settings.mcp.http')}
+            {t('common.cancel')}
           </button>
-        ))}
-      </div>
-
-      {transport === 'stdio' ? (
-        <>
-          <div>
-            <span className={label}>{t('settings.mcp.command')}</span>
-            <input
-              className={input}
-              value={command}
-              onChange={(e) => setCommand(e.target.value)}
-              placeholder="npx -y @scope/server"
-            />
-          </div>
-          <StrList
-            listLabel={t('settings.mcp.args')}
-            items={args}
-            onChange={setArgs}
-            addLabel={t('settings.mcp.addArg')}
-          />
-          <PairEditor
-            listLabel={t('settings.mcp.env')}
-            note={t('settings.mcp.envNote')}
-            items={env}
-            onChange={setEnv}
-            addLabel={t('settings.mcp.addEnv')}
-          />
-          <StrList
-            listLabel={t('settings.mcp.envPassthrough')}
-            note={t('settings.mcp.envPassthroughNote')}
-            items={envPassthrough}
-            onChange={setEnvPassthrough}
-            addLabel={t('settings.mcp.addVar')}
-          />
-          <div>
-            <span className={label}>{t('settings.mcp.cwd')}</span>
-            <input
-              className={input}
-              value={cwd}
-              onChange={(e) => setCwd(e.target.value)}
-              placeholder="~/code"
-            />
-          </div>
-        </>
-      ) : (
-        <>
-          <div>
-            <span className={label}>{t('settings.mcp.url')}</span>
-            <input
-              className={input}
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-              placeholder="https://mcp.example.com/mcp"
-            />
-          </div>
-          <div>
-            <span className={label}>{t('settings.mcp.bearerTokenEnvVar')}</span>
-            <input
-              className={input}
-              value={bearerTokenEnvVar}
-              onChange={(e) => setBearerTokenEnvVar(e.target.value)}
-              placeholder="MCP_BEARER_TOKEN"
-            />
-          </div>
-          <PairEditor
-            listLabel={t('settings.mcp.headers')}
-            note={t('settings.mcp.headersNote')}
-            items={headers}
-            onChange={setHeaders}
-            addLabel={t('settings.mcp.addHeader')}
-          />
-          <PairEditor
-            listLabel={t('settings.mcp.headersFromEnv')}
-            note={t('settings.mcp.headersFromEnvNote')}
-            items={headersFromEnv}
-            onChange={setHeadersFromEnv}
-            addLabel={t('settings.mcp.addVar')}
-          />
-        </>
-      )}
-
-      <label className="flex items-center gap-2 text-fg-secondary text-sm">
-        <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
-        {t('settings.mcp.enabled')}
-      </label>
-
-      {error && <p className="text-danger text-sm">{error}</p>}
-
-      <div className="flex items-center gap-2 pt-1">
-        <button
-          type="button"
-          onClick={save}
-          disabled={saving || !valid}
-          className="rounded-md bg-accent px-3 py-1.5 text-fg-on-accent text-sm hover:bg-accent-hover disabled:opacity-40"
-        >
-          {server ? t('common.save') : t('common.create')}
-        </button>
-        <button
-          type="button"
-          onClick={onCancel}
-          className="rounded-md px-3 py-1.5 text-fg-secondary text-sm hover:bg-elevated"
-        >
-          {t('common.cancel')}
-        </button>
+          <button
+            type="button"
+            onClick={save}
+            disabled={saving || !valid}
+            className="rounded-md bg-accent px-3 py-1.5 text-fg-on-accent text-sm hover:bg-accent-hover disabled:opacity-40"
+          >
+            {server ? t('common.save') : t('common.create')}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/src/components/settings/mcp/McpSection.tsx
+++ b/src/renderer/src/components/settings/mcp/McpSection.tsx
@@ -102,7 +102,9 @@ export function McpSection(): React.JSX.Element {
                 <X className="size-4" />
               </Dialog.Close>
             </div>
-            <div className="min-h-0 flex-1 overflow-hidden">
+            {/* The dialog is max-h (hugs short forms), so its height is indefinite and
+                percentage heights don't resolve inside — size the form via nested flex. */}
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
               {editing !== null && (
                 <McpForm
                   server={editing === 'new' ? null : editing}


### PR DESCRIPTION
## Problem

Opening the MCP server form with a long config (many args/env rows) clipped the bottom of the form: the body did not scroll and the save/cancel buttons were unreachable.

## Root cause

The form dialog uses `max-h-[85vh]` so it hugs short forms. With only a max-height, the dialog's height is indefinite, so the percentage height (`h-full`) inside never resolved — the form laid out at full content height and the wrapper's `overflow-hidden` clipped everything past the dialog edge. (The JSON editor dialog is unaffected because it uses a fixed `h-[85vh]`.)

Measured before the fix via CDP: dialog 697px tall, inner scroller `clientHeight` 1078px, `scrollable: false`, footer buttons laid out at y≈1200 — outside both the dialog and the viewport.

## Fix

- Size the form through nested flex (`min-h-0 flex-1`) instead of percentage heights, restoring body scrolling.
- Move save/cancel (and the error message) out of the scroll area into a pinned footer with a top border, so they stay visible however long the form is — matching the JSON editor dialog, including its right-aligned cancel/primary button order.

## Verification

Driven in the dev app over CDP:
- Long form (extra arg/env rows): dialog caps at 85vh, body scrolls (591/1078), footer buttons pinned and visible.
- Short form (new server): dialog still hugs content, no dead space.
- `bun run check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)