### PR TITLE
fix(mcp): drop blank args and env entries from server config

### DIFF
--- a/src/main/agent/mcp/config.test.ts
+++ b/src/main/agent/mcp/config.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'bun:test';
 import type { McpServerRow } from '../../db/schema';
-import { httpConfigSchema, resolveMcpServer, stdioConfigSchema } from './config';
+import { httpConfigSchema, mcpSecretsSchema, resolveMcpServer, stdioConfigSchema } from './config';
 
 const row = (over: Partial<McpServerRow>): McpServerRow =>
   ({
@@ -24,6 +24,63 @@ test('stdioConfigSchema applies defaults and requires a command', () => {
     cwd: undefined,
   });
   expect(() => stdioConfigSchema.parse({})).toThrow();
+});
+
+test('stdioConfigSchema drops blank args from an untouched form row', () => {
+  const c = stdioConfigSchema.parse({
+    command: 'npx',
+    args: ['@playwright/mcp@latest', '--extension', '', '   '],
+  });
+  expect(c.args).toEqual(['@playwright/mcp@latest', '--extension']);
+});
+
+test('stdioConfigSchema drops blank-key env/passthrough but keeps blank values', () => {
+  const c = stdioConfigSchema.parse({
+    command: 'srv',
+    env: { '': 'orphan', '  ': 'orphan2', TOKEN: 'x', EMPTY: '' },
+    envPassthrough: ['PATH', '', '  '],
+  });
+  expect(c.env).toEqual({ TOKEN: 'x', EMPTY: '' });
+  expect(c.envPassthrough).toEqual(['PATH']);
+});
+
+test('stdioConfigSchema trims the command and rejects a blank one', () => {
+  expect(stdioConfigSchema.parse({ command: '  npx  ' }).command).toBe('npx');
+  expect(() => stdioConfigSchema.parse({ command: '   ' })).toThrow();
+});
+
+test('stdioConfigSchema treats a blank cwd as unset', () => {
+  expect(stdioConfigSchema.parse({ command: 'srv', cwd: '   ' }).cwd).toBeUndefined();
+  expect(stdioConfigSchema.parse({ command: 'srv', cwd: '~/code' }).cwd).toBe('~/code');
+});
+
+test('httpConfigSchema drops blank-key headers and a blank bearer var', () => {
+  const c = httpConfigSchema.parse({
+    url: 'https://mcp.example.com',
+    headers: { '': 'orphan', 'X-App': 'atrium' },
+    headersFromEnv: { '': 'ENV', 'X-Token': 'MY_TOKEN_ENV' },
+    bearerTokenEnvVar: '  ',
+  });
+  expect(c.headers).toEqual({ 'X-App': 'atrium' });
+  expect(c.headersFromEnv).toEqual({ 'X-Token': 'MY_TOKEN_ENV' });
+  expect(c.bearerTokenEnvVar).toBeUndefined();
+});
+
+test('mcpSecretsSchema drops blank-key secret entries', () => {
+  expect(mcpSecretsSchema.parse({ env: { '': 'x', TOKEN: 'secret' } }).env).toEqual({
+    TOKEN: 'secret',
+  });
+});
+
+test('resolveMcpServer repairs a config already stored with a blank arg', () => {
+  const r = resolveMcpServer(
+    row({
+      transport: 'stdio',
+      config: { command: 'npx', args: ['@playwright/mcp@latest', '--extension', ''] },
+    }),
+    {},
+  );
+  expect(r).toMatchObject({ command: 'npx', args: ['@playwright/mcp@latest', '--extension'] });
 });
 
 test('httpConfigSchema validates the url and defaults headers', () => {

--- a/src/main/agent/mcp/config.ts
+++ b/src/main/agent/mcp/config.ts
@@ -9,19 +9,45 @@ import type { McpServerRow } from '../../db/schema';
  * only) so it stays unit-testable — the safeStorage crypto is in ./secrets.
  */
 
-const stringMap = z.record(z.string(), z.string());
+const isBlank = (s: string) => s.trim() === '';
+
+/*
+ * The settings form appends a fresh empty row for each arg and env var, so an
+ * untouched row reaches the schema as a blank "" arg or a nameless "" -> ""
+ * env entry. Left in, a blank arg becomes a stray positional on the command
+ * line (e.g. `npx @playwright/mcp --extension ""`), which some MCP servers
+ * reject on startup. Normalize the blanks away in the schema itself, so every
+ * write path (form, JSON editor, client import) and every read (connect time)
+ * is clean — a config already stored with blanks repairs itself when next parsed.
+ */
+const stringList = z
+  .array(z.string())
+  .default([])
+  .transform((xs) => xs.filter((x) => !isBlank(x)));
+
+// Drop entries with a blank key (a nameless env var / header). A blank *value*
+// is kept: `FOO=` is a legitimate empty env var.
+const stringMap = z
+  .record(z.string(), z.string())
+  .transform((m) => Object.fromEntries(Object.entries(m).filter(([k]) => !isBlank(k))));
+
+// A blank optional string (empty cwd / token) means "unset", not a literal "".
+const optionalString = z
+  .string()
+  .transform((s) => (isBlank(s) ? undefined : s))
+  .optional();
 
 /** stdio launch config; secret env values are layered in from McpSecrets. */
 export const stdioConfigSchema = z.object({
-  command: z.string().min(1),
-  args: z.array(z.string()).default([]),
+  command: z.string().trim().min(1),
+  args: stringList,
   // Non-secret env. Names whose values come from the host process belong in
   // envPassthrough; truly secret values belong in McpSecrets.env.
   env: stringMap.default({}),
   // Host env var names forwarded from process.env at connect time.
-  envPassthrough: z.array(z.string()).default([]),
+  envPassthrough: stringList,
   // Working directory; empty means the thread's workspace root.
-  cwd: z.string().optional(),
+  cwd: optionalString,
 });
 
 /** Streamable HTTP / SSE config; secret headers are layered in from McpSecrets. */
@@ -32,7 +58,7 @@ export const httpConfigSchema = z.object({
   headersFromEnv: stringMap.default({}),
   // Convenience for the common case: a host env var whose value becomes the
   // `Authorization: Bearer <value>` header at connect time.
-  bearerTokenEnvVar: z.string().optional(),
+  bearerTokenEnvVar: optionalString,
 });
 
 export type StdioConfig = z.infer<typeof stdioConfigSchema>;


### PR DESCRIPTION
## What

Normalizes MCP server config to strip blank inputs before they reach the launch command line:

- **Blank list items dropped** — a stray `""` in `args` (or `envPassthrough`) no longer becomes a positional argument.
- **Blank-key map entries dropped** — a nameless `"" -> "…"` env var / header is removed. Blank *values* are kept (`FOO=` is a legitimate empty env var).
- **Blank `cwd` / `bearerTokenEnvVar` → unset**, and the `command` is trimmed (a whitespace-only command is now rejected).

## Why

Reported by a user: the add-server form appends a fresh empty row per arg/env, and an untouched row was saved as `""`. That produced `npx @playwright/mcp@latest --extension ""`, and playwright-mcp rejected the stray positional `""` on startup.

## Where

The fix lives in the zod schema (`config.ts`), which is the single chokepoint every write path (form, JSON editor, client import) and every read (`resolveMcpServer` at connect time) funnels through. So it both prevents storing junk **and** repairs a config already stored with blanks on the next connect — no re-save needed.

## Tests

Added coverage in `config.test.ts` for each normalization (blank args, blank-key env/passthrough with blank values kept, command trim + blank-command reject, blank cwd, http headers/bearer, secrets, and an end-to-end `resolveMcpServer` repair of the exact reported config). Full MCP suite (40 tests), lint, and typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)