### PR TITLE
fix(chat): stop treating single-dollar text as inline math

### DIFF
--- a/src/renderer/src/components/chat/KatexMath.tsx
+++ b/src/renderer/src/components/chat/KatexMath.tsx
@@ -1,9 +1,9 @@
 import katex from 'katex';
 
 /**
- * Renders a LaTeX expression with KaTeX. remark-math turns `$…$` / `$$…$$`
- * into code nodes tagged `language-math` (+ `math-inline` / `math-display`);
- * we render them here instead of letting them fall through as code.
+ * Renders a LaTeX expression with KaTeX. remark-math turns `$$…$$` into code
+ * nodes tagged `language-math` (+ `math-inline` / `math-display`); we render
+ * them here instead of letting them fall through as code.
  */
 export function KatexMath({ tex, display }: { tex: string; display: boolean }): React.JSX.Element {
   const html = katex.renderToString(tex, { displayMode: display, throwOnError: false });

--- a/src/renderer/src/components/chat/Markdown.tsx
+++ b/src/renderer/src/components/chat/Markdown.tsx
@@ -14,15 +14,9 @@ import { LinkChip } from './LinkChip';
 import { MermaidDiagram } from './MermaidDiagram';
 import { TableBlock } from './TableBlock';
 
-/*
- * Math is opt-in in Streamdown. remark-math tags $$…$$ as `language-math`
- * code; we render those with KaTeX in the code renderer below.
- *
- * Single-dollar `$…$` is deliberately NOT math: chat text is full of dollar
- * amounts ($100亿, $85/股), and remark-math's default would grab the span
- * between two of them and typeset it as a formula. Inline math still works
- * via $$…$$ or a ```math fence.
- */
+// Math is opt-in in Streamdown. remark-math tags $$…$$ as `language-math`
+// code; we render those with KaTeX in the code renderer below. Single-dollar
+// math is disabled so dollar amounts in plain text don't parse as formulas.
 const remarkPlugins: NonNullable<StreamdownProps['remarkPlugins']> = [
   ...Object.values(defaultRemarkPlugins),
   [remarkMath, { singleDollarTextMath: false }],

--- a/src/renderer/src/components/chat/Markdown.tsx
+++ b/src/renderer/src/components/chat/Markdown.tsx
@@ -1,16 +1,32 @@
 import 'katex/dist/katex.min.css';
 import { useMemo } from 'react';
 import remarkMath from 'remark-math';
-import { type AnimateOptions, type Components, defaultRemarkPlugins, Streamdown } from 'streamdown';
+import {
+  type AnimateOptions,
+  type Components,
+  defaultRemarkPlugins,
+  Streamdown,
+  type StreamdownProps,
+} from 'streamdown';
 import { CodeBlock } from './CodeBlock';
 import { MathFence } from './KatexMath';
 import { LinkChip } from './LinkChip';
 import { MermaidDiagram } from './MermaidDiagram';
 import { TableBlock } from './TableBlock';
 
-// Math is opt-in in Streamdown. remark-math tags $…$ / $$…$$ as `language-math`
-// code; we render those with KaTeX in the code renderer below.
-const remarkPlugins = [...Object.values(defaultRemarkPlugins), remarkMath];
+/*
+ * Math is opt-in in Streamdown. remark-math tags $$…$$ as `language-math`
+ * code; we render those with KaTeX in the code renderer below.
+ *
+ * Single-dollar `$…$` is deliberately NOT math: chat text is full of dollar
+ * amounts ($100亿, $85/股), and remark-math's default would grab the span
+ * between two of them and typeset it as a formula. Inline math still works
+ * via $$…$$ or a ```math fence.
+ */
+const remarkPlugins: NonNullable<StreamdownProps['remarkPlugins']> = [
+  ...Object.values(defaultRemarkPlugins),
+  [remarkMath, { singleDollarTextMath: false }],
+];
 
 /**
  * Renders assistant text as Markdown via Streamdown — streaming-safe (it styles


### PR DESCRIPTION
## 问题

财经类文本中成对出现的单美元符会被 remark-math 误判为 inline math，例如：

```md
- Crinetics **+99%盘中** — Vertex以$100亿收购（$85/股全现金）
```

`$100亿收购（$` 之间的内容被 KaTeX 以数学字体渲染，字号变大并异常换行。

## 根因

`remark-math` 默认 `singleDollarTextMath: true`，把 `$…$` 当作 inline math。聊天里美元金额（$100、$85、$345）远比行内公式常见，成对出现即误判。

## 修复

关闭单美元 inline math，保留 `$$…$$` 与 ```math fence：

```ts
const remarkPlugins: NonNullable<StreamdownProps['remarkPlugins']> = [
  ...Object.values(defaultRemarkPlugins),
  [remarkMath, { singleDollarTextMath: false }],
];
```

类型直接从 `StreamdownProps` 派生（unified `PluggableList`），无手写 shim。

## 验证

remark 管道对照（旧配置复现 `inlineMath:"100亿收购（"`，新配置无 math 节点）+ 在运行中的 dev App 里用真实 `Markdown` 组件渲染 7 个用例全部通过：财经文本/单美元金额原样显示；`$$x+1$$`、块级 `$$…$$`、```math fence、行内 `$$…$$` 均正常走 KaTeX；真实历史会话（含 $800M/$8.3B 文本）渲染无回归。

## 行为取舍

`$x+1$` 不再渲染为公式（按字面显示）。需要行内公式时用 `$$x+1$$` 或 ```math fence。

🤖 Generated with [Claude Code](https://claude.com/claude-code)