### PR TITLE
fix(tools): detect search bot challenges and fall back across engines

### DIFF
--- a/src/main/agent/tools/builtins/web-search.ts
+++ b/src/main/agent/tools/builtins/web-search.ts
@@ -1,6 +1,6 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { DDG, formatResults } from './web/engines';
+import { ENGINES, formatResults } from './web/engines';
 import { runSearch } from './web/run-search';
 
 export const webSearchTool = () =>
@@ -11,11 +11,20 @@ export const webSearchTool = () =>
       query: z.string().min(1).describe('The search query.'),
     }),
     execute: async ({ query }, { abortSignal }) => {
-      try {
-        const results = await runSearch(DDG, query, abortSignal);
-        return formatResults(query, results);
-      } catch (err) {
-        return `Error: ${err instanceof Error ? err.message : String(err)}`;
+      // Engines are tried in order: a bot challenge or timeout on one falls
+      // through to the next, so only a failure across all of them surfaces as
+      // an error. "No results found" is reserved for a genuinely empty page.
+      const failures: string[] = [];
+      for (const engine of ENGINES) {
+        try {
+          const results = await runSearch(engine, query, abortSignal);
+          return formatResults(query, results);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (abortSignal?.aborted) return `Error: ${msg}`;
+          failures.push(`${engine.name}: ${msg}`);
+        }
       }
+      return `Error: all search engines failed — ${failures.join('; ')}`;
     },
   });

--- a/src/main/agent/tools/builtins/web/engines.test.ts
+++ b/src/main/agent/tools/builtins/web/engines.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from 'bun:test';
-import { formatResults, parseDdgResults, type RawResult } from './engines';
+import {
+  formatResults,
+  parseBingResults,
+  parseBraveResults,
+  parseDdgResults,
+  type RawResult,
+} from './engines';
 
 const redirect = (realUrl: string) =>
   `https://duckduckgo.com/l/?uddg=${encodeURIComponent(realUrl)}&rut=abc123`;
@@ -53,6 +59,43 @@ test('skips entries missing a title or an unparseable href', () => {
     { title: 'Bad', href: 'not a url', snippet: '' },
   ];
   expect(parseDdgResults(raw)).toEqual([]);
+});
+
+test('keeps direct Brave hrefs and drops links staying on brave.com', () => {
+  const raw: RawResult[] = [
+    { title: 'Harness: AI for DevOps', href: 'https://www.harness.io/', snippet: 'CI/CD' },
+    { title: 'Brave feature', href: 'https://search.brave.com/help', snippet: '' },
+    { title: 'Bad', href: 'not a url', snippet: '' },
+  ];
+  expect(parseBraveResults(raw)).toEqual([
+    { title: 'Harness: AI for DevOps', url: 'https://www.harness.io/', snippet: 'CI/CD' },
+  ]);
+});
+
+test('decodes the destination out of the Bing /ck/a redirect wrapper', () => {
+  const dest = 'https://harness-engineering.ai/blog/agent-harness-complete-guide/';
+  const u = `a1${Buffer.from(dest, 'utf8').toString('base64url')}`;
+  const raw: RawResult[] = [
+    {
+      title: 'The Complete Guide to Agent Harness',
+      href: `https://www.bing.com/ck/a?!&&p=abc&u=${u}&ntb=1`,
+      snippet: 'An agent harness is…',
+    },
+  ];
+  expect(parseBingResults(raw)).toEqual([
+    { title: 'The Complete Guide to Agent Harness', url: dest, snippet: 'An agent harness is…' },
+  ]);
+});
+
+test('drops Bing links whose destination stays on bing.com', () => {
+  const u = `a1${Buffer.from('https://www.bing.com/images', 'utf8').toString('base64url')}`;
+  const raw: RawResult[] = [
+    { title: 'Images', href: `https://www.bing.com/ck/a?u=${u}`, snippet: '' },
+    { title: 'Plain', href: 'https://example.com/page', snippet: '' },
+  ];
+  expect(parseBingResults(raw)).toEqual([
+    { title: 'Plain', url: 'https://example.com/page', snippet: '' },
+  ]);
 });
 
 test('formats results as a numbered markdown list', () => {

--- a/src/main/agent/tools/builtins/web/engines.ts
+++ b/src/main/agent/tools/builtins/web/engines.ts
@@ -18,6 +18,10 @@ export type SearchEngine = {
   buildUrl: (query: string) => string;
   /** Polled in-page (count expression) to know results have rendered. */
   readyExpr: string;
+  /** Truthy in-page expression when the engine shows a bot challenge instead of results. */
+  challengeExpr?: string;
+  /** Truthy in-page expression when the engine rendered a genuine no-results state. */
+  emptyExpr?: string;
   /** In-page JS (IIFE) returning RawResult[]. */
   scrapeScript: string;
   /** Decode/clean the raw scrape into final results. */
@@ -76,9 +80,102 @@ export const DDG: SearchEngine = {
   name: 'duckduckgo',
   buildUrl: (query) => `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`,
   readyExpr: 'document.querySelectorAll(\'a.result__a[href*="uddg"]\').length',
+  challengeExpr: '!!document.querySelector(\'[class*="anomaly-modal"], #challenge-form\')',
+  emptyExpr: "!!document.querySelector('.no-results')",
   scrapeScript: DDG_SCRAPE,
   parse: parseDdgResults,
 };
+
+const BRAVE_SCRAPE = `(() => {
+  const out = [];
+  for (const s of document.querySelectorAll('.snippet[data-type="web"]')) {
+    const a = s.querySelector('a[href^="http"]');
+    const title = s.querySelector('.title');
+    if (!a || !title) continue;
+    const desc = s.querySelector('.content, p');
+    out.push({
+      title: (title.textContent || '').trim(),
+      href: a.href,
+      snippet: (desc ? desc.textContent : '').trim(),
+    });
+  }
+  return out;
+})()`;
+
+/** Brave links point straight at the destination; drop anything staying on brave.com. */
+export function parseBraveResults(raw: RawResult[]): SearchResult[] {
+  const out: SearchResult[] = [];
+  for (const r of raw) {
+    if (!r.title || !r.href) continue;
+    let host: string;
+    try {
+      host = new URL(r.href).hostname;
+    } catch {
+      continue;
+    }
+    if (host === 'brave.com' || host.endsWith('.brave.com')) continue;
+    out.push({ title: r.title, url: r.href, snippet: r.snippet });
+  }
+  return out;
+}
+
+export const BRAVE: SearchEngine = {
+  name: 'brave',
+  buildUrl: (query) => `https://search.brave.com/search?q=${encodeURIComponent(query)}`,
+  readyExpr: 'document.querySelectorAll(\'.snippet[data-type="web"]\').length',
+  scrapeScript: BRAVE_SCRAPE,
+  parse: parseBraveResults,
+};
+
+const BING_SCRAPE = `(() => {
+  const out = [];
+  for (const li of document.querySelectorAll('li.b_algo')) {
+    const a = li.querySelector('h2 a');
+    if (!a) continue;
+    const desc = li.querySelector('.b_caption p, p');
+    out.push({
+      title: (a.textContent || '').trim(),
+      href: a.href,
+      snippet: (desc ? desc.textContent : '').trim(),
+    });
+  }
+  return out;
+})()`;
+
+/**
+ * Bing wraps every hit in a `bing.com/ck/a` redirect; the destination is the
+ * base64url-encoded `u` param, prefixed with "a1". Unwrap it and drop anything
+ * still pointing at bing.com.
+ */
+export function parseBingResults(raw: RawResult[]): SearchResult[] {
+  const out: SearchResult[] = [];
+  for (const r of raw) {
+    if (!r.title || !r.href) continue;
+    let url = r.href;
+    try {
+      const href = new URL(r.href);
+      const u = href.searchParams.get('u');
+      if (u?.startsWith('a1')) url = Buffer.from(u.slice(2), 'base64url').toString('utf8');
+      const host = new URL(url).hostname;
+      if (host === 'bing.com' || host.endsWith('.bing.com')) continue;
+    } catch {
+      continue;
+    }
+    out.push({ title: r.title, url, snippet: r.snippet });
+  }
+  return out;
+}
+
+export const BING: SearchEngine = {
+  name: 'bing',
+  buildUrl: (query) => `https://www.bing.com/search?q=${encodeURIComponent(query)}`,
+  readyExpr: "document.querySelectorAll('li.b_algo').length",
+  scrapeScript: BING_SCRAPE,
+  parse: parseBingResults,
+};
+
+/** Tried in order; a blocked or timed-out engine falls through to the next. */
+export const ENGINES: SearchEngine[] = [DDG, BRAVE, BING];
 
 /** Render results as a compact numbered Markdown list for the model. */
 export function formatResults(query: string, results: SearchResult[]): string {

--- a/src/main/agent/tools/builtins/web/run-search.ts
+++ b/src/main/agent/tools/builtins/web/run-search.ts
@@ -16,9 +16,18 @@ const MAX_ATTEMPTS = 2;
 const RETRY_BACKOFF_MS = 2_500;
 
 // Single-file mutex: every search chains off the previous one, so only one
-// hidden window ever drives DDG at a time and the next waits its turn.
+// hidden window ever drives an engine at a time and the next waits its turn.
 let queue: Promise<unknown> = Promise.resolve();
-let lastSearchEndedAt = 0;
+// Rate limiting is per engine, so falling back to another engine never waits.
+const lastEndedAt = new Map<string, number>();
+
+/** The engine served a bot challenge instead of results; retrying won't clear it. */
+export class SearchBlockedError extends Error {
+  constructor() {
+    super('blocked by a bot-challenge page');
+    this.name = 'SearchBlockedError';
+  }
+}
 
 // Electron is required lazily so this module imports cleanly outside an Electron
 // runtime (e.g. the bun test runner), matching how the agent runner defers it.
@@ -61,7 +70,7 @@ async function throttledSearch(
   signal?: AbortSignal,
 ): Promise<SearchResult[]> {
   throwIfAborted(signal);
-  const sinceLast = Date.now() - lastSearchEndedAt;
+  const sinceLast = Date.now() - (lastEndedAt.get(engine.name) ?? 0);
   if (sinceLast < MIN_GAP_MS) await delay(MIN_GAP_MS - sinceLast, signal);
   try {
     let lastErr: unknown;
@@ -70,14 +79,15 @@ async function throttledSearch(
       try {
         return await attemptSearch(engine, query, signal);
       } catch (err) {
-        if (signal?.aborted) throw err; // a stop isn't a retryable failure
+        // A stop isn't retryable, and a bot challenge won't clear in one backoff.
+        if (signal?.aborted || err instanceof SearchBlockedError) throw err;
         lastErr = err;
         if (attempt < MAX_ATTEMPTS) await delay(RETRY_BACKOFF_MS, signal);
       }
     }
     throw lastErr;
   } finally {
-    lastSearchEndedAt = Date.now();
+    lastEndedAt.set(engine.name, Date.now());
   }
 }
 
@@ -103,7 +113,11 @@ async function attemptSearch(
     throwIfAborted(signal);
     const wc = win.webContents;
     await withTimeout(wc.loadURL(engine.buildUrl(query)), NAV_TIMEOUT_MS, 'navigation');
-    await pollFor(wc, engine.readyExpr, RESULTS_TIMEOUT_MS, signal);
+    const state = await pollForState(wc, engine, RESULTS_TIMEOUT_MS, signal);
+    if (state === 'challenge') throw new SearchBlockedError();
+    if (state === 'timeout')
+      throw new Error(`rendered no results within ${RESULTS_TIMEOUT_MS / 1000}s`);
+    if (state === 'empty') return [];
     const raw = await wc.executeJavaScript(engine.scrapeScript);
     return engine.parse(Array.isArray(raw) ? raw : []);
   } finally {
@@ -112,20 +126,33 @@ async function attemptSearch(
   }
 }
 
-/** Resolve once the in-page count expression goes truthy, or stop at timeout. */
-async function pollFor(
+type PageState = 'ready' | 'empty' | 'challenge' | 'timeout';
+
+/**
+ * Poll until the page settles into a recognizable state. A challenge is checked
+ * first so a blocked engine fails over in under a second instead of burning the
+ * whole results timeout; only a page that never settles reports 'timeout'.
+ */
+async function pollForState(
   wc: WebContents,
-  countExpr: string,
+  engine: SearchEngine,
   timeoutMs: number,
   signal?: AbortSignal,
-): Promise<void> {
+): Promise<PageState> {
+  const classifyExpr = `(() => {
+    if (${engine.challengeExpr ?? 'false'}) return 'challenge';
+    if (${engine.readyExpr}) return 'ready';
+    if (${engine.emptyExpr ?? 'false'}) return 'empty';
+    return '';
+  })()`;
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     throwIfAborted(signal);
-    const n = await wc.executeJavaScript(countExpr).catch(() => 0);
-    if (n) return;
+    const state = await wc.executeJavaScript(classifyExpr).catch(() => '');
+    if (state) return state as PageState;
     await delay(POLL_INTERVAL_MS, signal);
   }
+  return 'timeout';
 }
 
 function delay(ms: number, signal?: AbortSignal): Promise<void> {


### PR DESCRIPTION
## 问题

在部分网络环境（尤其公司出口 NAT IP）下,DuckDuckGo 会对隐藏搜索窗口弹交互式 bot 验证码。原实现中 `pollFor` 超时静默返回,空抓取结果被 `formatResults` 包装成 **"No results found"** —— 模型以为搜索成功且确实无结果,答非所问。

## 根因

- `run-search.ts` 的 `pollFor` 超时后静默返回,不区分「页面被验证码占据」「页面没渲染完」「真的无结果」
- `engines.ts` 只有 DDG 一个引擎,无 fallback
- 空数组一律格式化为 "No results found"

## 修复

1. **结果轮询改为状态分类**:每个 tick 依次判 challenge → ready → empty,页面一出现验证码就在 ~200ms 内抛 `SearchBlockedError`(不再烧满 12s 超时),超时也抛明确错误
2. **DDG 验证码检测**:`[class*="anomaly-modal"], #challenge-form`(选择器取自真实挑战页采样)
3. **引擎 fallback 链 DDG → Brave → Bing**:被拦/超时自动换下一个;Brave 直链无跳转,Bing 的 `/ck/a` 跳转按 base64url `u` 参数解包(均从真实 Chromium 窗口采样验证)。节流间隔改为按引擎计,fallback 无额外等待;`SearchBlockedError` 不做引擎内重试
4. **"No results found" 只保留给真实空结果**:引擎渲染出无结果状态才返回;全引擎失败时返回按引擎列明原因的 Error,模型能感知工具失败

## 验证

- 单测 11 项(新增 Brave/Bing parse 用例),全仓 502 测试通过,typecheck/lint 绿
- **运行时 harness**(真实 Electron 隐藏窗口驱动分支上的真实 `runSearch`):
  - 验证码 fixture → 210ms 抛 SearchBlockedError(原:12s 静默超时 + 误报)
  - 结果/空页 fixture → 正确解析 / 正确返回 0 条
  - 空白页 fixture → 两次尝试后抛超时错误(27.3s)
  - 搜索中途 abort → 814ms 拒绝,窗口即刻销毁
  - live 实测三引擎:DDG 10 条 / Brave 20 条 / Bing 10 条(跳转解码正确)
- **App 级 e2e**(dev 实例真实对话):web_search "AI harness" 返回真实结果(harness-engineering.ai、Best of Agent Harnesses 等);流式回合中点停止按钮,36ms 内回合终止
- 本机 curl 同一 DDG 端点复现 HTTP 202 验证码页,与被拦机器的现象一致

## 行为说明

DDG/Brave 对乱码查询会模糊匹配出结果,真实空结果页极少见;若引擎既无结果也无空状态标记,现在报超时错误而非假 "No results found"。

🤖 Generated with [Claude Code](https://claude.com/claude-code)