### PR TITLE
chore(scripts): add cdp screenshot tool

### DIFF
--- a/scripts/beautify-screenshot.swift
+++ b/scripts/beautify-screenshot.swift
@@ -1,0 +1,61 @@
+/*
+ * Rounds the corners of a screenshot and floats it on a soft drop shadow over
+ * a transparent canvas — the same look macOS window capture (⇧⌘5) produces,
+ * which CDP screenshots lack. Invoked by scripts/screenshot.ts; also usable
+ * standalone: swift scripts/beautify-screenshot.swift <in.png> <out.png> [radius] [pad]
+ */
+import AppKit
+import CoreGraphics
+
+let args = CommandLine.arguments
+guard args.count >= 3 else {
+  FileHandle.standardError.write(Data("usage: beautify-screenshot.swift <in.png> <out.png> [radius] [pad]\n".utf8))
+  exit(1)
+}
+let inPath = args[1]
+let outPath = args[2]
+let radius: CGFloat = args.count > 3 ? CGFloat(Double(args[3]) ?? 28) : 28
+let pad: CGFloat = args.count > 4 ? CGFloat(Double(args[4]) ?? 110) : 110
+
+guard let image = NSImage(contentsOfFile: inPath),
+      let source = image.cgImage(forProposedRect: nil, context: nil, hints: nil)
+else {
+  FileHandle.standardError.write(Data("could not read \(inPath)\n".utf8))
+  exit(1)
+}
+let width = CGFloat(source.width)
+let height = CGFloat(source.height)
+
+let context = CGContext(
+  data: nil,
+  width: Int(width + pad * 2),
+  height: Int(height + pad * 2),
+  bitsPerComponent: 8,
+  bytesPerRow: 0,
+  space: CGColorSpace(name: CGColorSpace.sRGB)!,
+  bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+)!
+
+let rect = CGRect(x: pad, y: pad, width: width, height: height)
+let path = CGPath(roundedRect: rect, cornerWidth: radius, cornerHeight: radius, transform: nil)
+
+context.saveGState()
+context.setShadow(
+  offset: CGSize(width: 0, height: -30),
+  blur: 90,
+  color: CGColor(red: 0, green: 0, blue: 0, alpha: 0.38)
+)
+context.addPath(path)
+context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+context.fillPath()
+context.restoreGState()
+
+context.saveGState()
+context.addPath(path)
+context.clip()
+context.draw(source, in: rect)
+context.restoreGState()
+
+let rendered = context.makeImage()!
+let representation = NSBitmapImageRep(cgImage: rendered)
+try! representation.representation(using: .png, properties: [:])!.write(to: URL(fileURLWithPath: outPath))

--- a/scripts/screenshot.ts
+++ b/scripts/screenshot.ts
@@ -1,0 +1,112 @@
+/*
+ * Captures a README-ready screenshot of the running app over the Chrome
+ * DevTools Protocol, then post-processes it with rounded corners and a drop
+ * shadow (scripts/beautify-screenshot.swift) so it matches the existing
+ * images/ set. CDP is used instead of macOS screencapture because window
+ * capture requires a Screen Recording grant per terminal, while the debug
+ * port needs nothing.
+ *
+ * The app must be listening on the debug port first:
+ *   packaged: /Applications/Atrium.app/Contents/MacOS/Atrium --remote-debugging-port=9333
+ *   dev:      REMOTE_DEBUGGING_PORT=9333 bun run dev
+ *
+ * Usage:
+ *   bun scripts/screenshot.ts --out images/providers.png --hash "#/settings/providers"
+ *   bun scripts/screenshot.ts --out shot.png --eval "document.querySelector('aside').scrollTop = 0"
+ *
+ * Flags: --out <file> (required), --hash <route>, --eval <js> (staging step,
+ * runs after navigation), --delay <ms> (settle time, default 1500),
+ * --port <n> (default 9333), --raw (skip beautify).
+ * After replacing screenshots, refresh the README carousel with
+ * scripts/make-showcase.ts.
+ */
+const args = Bun.argv.slice(2);
+const flag = (name: string) => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+const out = flag('out');
+if (!out) {
+  console.error(
+    'usage: bun scripts/screenshot.ts --out <file> [--hash <route>] [--eval <js>] [--delay <ms>] [--port <n>] [--raw]',
+  );
+  process.exit(1);
+}
+const port = flag('port') ?? '9333';
+const delay = Number(flag('delay') ?? 1500);
+const hash = flag('hash');
+const evalExpr = flag('eval');
+const raw = args.includes('--raw');
+
+const targets = (await (
+  await fetch(`http://127.0.0.1:${port}/json`).catch(() => {
+    console.error(
+      `no CDP endpoint on port ${port} — launch the app with --remote-debugging-port=${port}`,
+    );
+    process.exit(1);
+  })
+).json()) as Array<{ type: string; webSocketDebuggerUrl: string }>;
+const page = targets.find((t) => t.type === 'page');
+if (!page) {
+  console.error('no page target found');
+  process.exit(1);
+}
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve) => {
+  ws.onopen = resolve;
+});
+let seq = 0;
+const pending = new Map<number, (v: { result?: { data?: string }; error?: unknown }) => void>();
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data as string);
+  pending.get(msg.id)?.(msg);
+  pending.delete(msg.id);
+};
+const send = (method: string, params: object = {}) => {
+  const id = ++seq;
+  ws.send(JSON.stringify({ id, method, params }));
+  return new Promise<{ result?: { data?: string }; error?: unknown }>((resolve) =>
+    pending.set(id, resolve),
+  );
+};
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+if (hash) {
+  await send('Runtime.evaluate', { expression: `location.hash = ${JSON.stringify(hash)}` });
+  await sleep(delay);
+}
+if (evalExpr) {
+  const result = await send('Runtime.evaluate', {
+    expression: `(async () => { ${evalExpr} })()`,
+    awaitPromise: true,
+  });
+  if (result.error) {
+    console.error('eval failed:', result.error);
+    process.exit(1);
+  }
+  await sleep(500);
+}
+
+const shot = await send('Page.captureScreenshot', { format: 'png' });
+if (!shot.result?.data) {
+  console.error('capture failed:', shot.error);
+  process.exit(1);
+}
+await Bun.write(out, Buffer.from(shot.result.data, 'base64'));
+ws.close();
+
+if (!raw) {
+  const beautify = Bun.spawnSync([
+    'swift',
+    new URL('beautify-screenshot.swift', import.meta.url).pathname,
+    out,
+    out,
+  ]);
+  if (beautify.exitCode !== 0) {
+    console.error(`beautify failed: ${beautify.stderr.toString()}`);
+    process.exit(1);
+  }
+}
+console.log(out);
+process.exit(0);


### PR DESCRIPTION
## What

- `scripts/screenshot.ts` — captures a page of the running app over CDP and post-processes it into the README screenshot style. Example:
  ```bash
  # launch the app with the debug port first:
  #   packaged: /Applications/Atrium.app/Contents/MacOS/Atrium --remote-debugging-port=9333
  #   dev:      REMOTE_DEBUGGING_PORT=9333 bun run dev
  bun scripts/screenshot.ts --out images/providers.png --hash "#/settings/providers"
  ```
  Flags: `--hash` (route to open), `--eval` (staging JS, e.g. scroll or expand a section), `--delay`, `--port`, `--raw` (skip post-processing).
- `scripts/beautify-screenshot.swift` — rounded corners + drop shadow on a transparent canvas (the ⇧⌘5 window-capture look), also usable standalone.

## Why

CDP capture works without the per-terminal Screen Recording permission macOS window capture requires, and the beautify pass keeps every future screenshot visually consistent with the existing `images/` set. Together with `scripts/make-showcase.ts` this makes "screenshot a new feature → refresh the README carousel" a two-command flow.

Verified end-to-end against the running 0.10.2 app (`--hash "#/settings/mcp"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)