### PR TITLE
docs(readme): drop the screenshot carousel

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ own key, with all the AI-agent capabilities you'd expect today.
 
 https://github.com/user-attachments/assets/49af7cb9-f11c-4cce-8fd8-c45e3dcbbd8f
 
-<img src="images/showcase.svg" alt="Atrium screenshots" />
-
 ## Features
 
 - **Multi-provider:** Anthropic, Google Gemini, any OpenAI-compatible endpoint, local models

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,8 +18,6 @@ Atrium 是一款本地优先的桌面 AI Agent 助手。支持携带秘钥接入
 
 https://github.com/user-attachments/assets/49af7cb9-f11c-4cce-8fd8-c45e3dcbbd8f
 
-<img src="images/showcase.svg" alt="Atrium 界面截图" />
-
 ## 功能特性
 
 - **多供应商支持：** Anthropic、Google Gemini、任意 OpenAI 兼容端点、通过 Ollama 运行的本地模型，以及外部 CLI agent（Claude Code、Codex、Gemini CLI）- 全部使用你自己的密钥，并在本地加密。


### PR DESCRIPTION
Removes the showcase carousel from both READMEs — the demo section reads cleaner with just the video. `images/showcase.svg`, the screenshots, and `scripts/make-showcase.ts` stay for external posts (weekly issue, other platforms) to reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)