### PR TITLE
fix(chat): keep link favicons visible with blank and dark-icon fallbacks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -74,6 +74,7 @@
         "codemirror": "^6.0.2",
         "croner": "^10",
         "cronstrue": "^3",
+        "decode-ico": "^0.4.1",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",
         "electron": "^39.2.6",
@@ -210,6 +211,8 @@
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@canvas/image-data": ["@canvas/image-data@1.1.0", "", {}, "sha512-QdObRRjRbcXGmM1tmJ+MrHcaz1MftF2+W7YI+MsphnsCrmtyfS0d5qJbk0MeSbUeyM/jCb0hmnkXPsy026L7dA=="],
 
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
@@ -1263,6 +1266,10 @@
 
     "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
+    "decode-bmp": ["decode-bmp@0.2.1", "", { "dependencies": { "@canvas/image-data": "^1.0.0", "to-data-view": "^1.1.0" } }, "sha512-NiOaGe+GN0KJqi2STf24hfMkFitDUaIoUU3eKvP/wAbLe8o6FuW5n/x7MHPR0HKvBokp6MQY/j7w8lewEeVCIA=="],
+
+    "decode-ico": ["decode-ico@0.4.1", "", { "dependencies": { "@canvas/image-data": "^1.0.0", "decode-bmp": "^0.2.0", "to-data-view": "^1.1.0" } }, "sha512-69NZfbKIzux1vBOd31al3XnMnH+2mqDhEgLdpygErm4d60N+UwA5Sq5WFjmEDQzumgB9fElojGwWG0vybVfFmA=="],
+
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
@@ -2288,6 +2295,8 @@
     "tmp": ["tmp@0.2.6", "", {}, "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA=="],
 
     "tmp-promise": ["tmp-promise@3.0.3", "", { "dependencies": { "tmp": "^0.2.0" } }, "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ=="],
+
+    "to-data-view": ["to-data-view@1.1.0", "", {}, "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "codemirror": "^6.0.2",
     "croner": "^10",
     "cronstrue": "^3",
+    "decode-ico": "^0.4.1",
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.2",
     "electron": "^39.2.6",

--- a/src/main/favicons.ts
+++ b/src/main/favicons.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import decodeIco from 'decode-ico';
 import { app, protocol } from 'electron';
 import { parseHTML } from 'linkedom';
 import { createLogger } from './log';
@@ -111,23 +112,19 @@ async function get(
  * Some servers pipe favicon bytes through a text-encoding layer that mangles
  * the binary into UTF-8 replacement characters. Chromium still "decodes" such
  * an ICO — to fully transparent pixels — so the renderer's error fallback never
- * fires. A real ICO's directory always fits inside the file; one that doesn't
- * is rejected here so the lookup falls through to the next source.
+ * fires; a file decode-ico can't parse is rejected here so the lookup falls
+ * through to the next source. Only bytes carrying the ICO magic are checked:
+ * many sites serve a PNG at the favicon path, which decode-ico would reject.
  */
 function isCorruptIco(bytes: Uint8Array): boolean {
   const b = bytes;
   if (b.length < 6 || b[0] !== 0 || b[1] !== 0 || b[2] !== 1 || b[3] !== 0) return false;
-  const view = new DataView(b.buffer, b.byteOffset, b.byteLength);
-  const count = view.getUint16(4, true);
-  const dirEnd = 6 + count * 16;
-  if (count === 0 || dirEnd > b.length) return true;
-  for (let i = 0; i < count; i++) {
-    const entry = 6 + i * 16;
-    const size = view.getUint32(entry + 8, true);
-    const offset = view.getUint32(entry + 12, true);
-    if (size === 0 || offset < dirEnd || offset + size > b.length) return true;
+  try {
+    decodeIco(bytes);
+    return false;
+  } catch {
+    return true;
   }
-  return false;
 }
 
 function asImage(res: { bytes: Uint8Array<ArrayBuffer>; type: string | null }): Favicon | null {

--- a/src/main/favicons.ts
+++ b/src/main/favicons.ts
@@ -107,7 +107,31 @@ async function get(
   };
 }
 
+/**
+ * Some servers pipe favicon bytes through a text-encoding layer that mangles
+ * the binary into UTF-8 replacement characters. Chromium still "decodes" such
+ * an ICO — to fully transparent pixels — so the renderer's error fallback never
+ * fires. A real ICO's directory always fits inside the file; one that doesn't
+ * is rejected here so the lookup falls through to the next source.
+ */
+function isCorruptIco(bytes: Uint8Array): boolean {
+  const b = bytes;
+  if (b.length < 6 || b[0] !== 0 || b[1] !== 0 || b[2] !== 1 || b[3] !== 0) return false;
+  const view = new DataView(b.buffer, b.byteOffset, b.byteLength);
+  const count = view.getUint16(4, true);
+  const dirEnd = 6 + count * 16;
+  if (count === 0 || dirEnd > b.length) return true;
+  for (let i = 0; i < count; i++) {
+    const entry = 6 + i * 16;
+    const size = view.getUint32(entry + 8, true);
+    const offset = view.getUint32(entry + 12, true);
+    if (size === 0 || offset < dirEnd || offset + size > b.length) return true;
+  }
+  return false;
+}
+
 function asImage(res: { bytes: Uint8Array<ArrayBuffer>; type: string | null }): Favicon | null {
+  if (isCorruptIco(res.bytes)) return null;
   const ct = res.type?.startsWith('image/') ? res.type : sniff(res.bytes);
   return ct ? { bytes: res.bytes, contentType: ct } : null;
 }
@@ -195,12 +219,14 @@ async function load(host: string): Promise<Favicon | null> {
   if (existsSync(path)) {
     try {
       const raw = await readFile(path);
-      const fav: Favicon = {
-        bytes: new Uint8Array(raw),
-        contentType: sniff(raw) ?? 'image/x-icon',
-      };
-      mem.set(host, fav);
-      return fav;
+      const bytes = new Uint8Array(raw);
+      // A corrupt icon cached before validation existed must not be served
+      // forever — ignore it and re-resolve.
+      if (!isCorruptIco(bytes)) {
+        const fav: Favicon = { bytes, contentType: sniff(raw) ?? 'image/x-icon' };
+        mem.set(host, fav);
+        return fav;
+      }
     } catch {
       // Unreadable cache file — fall through and re-fetch.
     }
@@ -231,11 +257,16 @@ export async function getFavicon(host: string): Promise<Favicon | null> {
   return p;
 }
 
-// Must run before app 'ready'. `standard` gives the URL a parseable host and
-// `secure` keeps the images from counting as insecure content in the renderer.
+// Must run before app 'ready'. `standard` gives the URL a parseable host,
+// `secure` keeps the images from counting as insecure content, and
+// `corsEnabled` (with the allow-origin header below) lets the renderer load
+// them as crossorigin images whose pixels it may inspect for visibility.
 export function registerFaviconScheme(): void {
   protocol.registerSchemesAsPrivileged([
-    { scheme: SCHEME, privileges: { standard: true, secure: true, supportFetchAPI: false } },
+    {
+      scheme: SCHEME,
+      privileges: { standard: true, secure: true, supportFetchAPI: false, corsEnabled: true },
+    },
   ]);
 }
 
@@ -251,7 +282,11 @@ export function serveFavicons(): void {
     if (!fav) return new Response(null, { status: 404 });
     return new Response(fav.bytes, {
       status: 200,
-      headers: { 'content-type': fav.contentType, 'cache-control': 'max-age=86400' },
+      headers: {
+        'content-type': fav.contentType,
+        'cache-control': 'max-age=86400',
+        'access-control-allow-origin': '*',
+      },
     });
   });
 }

--- a/src/renderer/src/components/chat/LinkChip.tsx
+++ b/src/renderer/src/components/chat/LinkChip.tsx
@@ -17,20 +17,67 @@ function textOf(node: ReactNode): string {
   return '';
 }
 
+/**
+ * A favicon can load "successfully" yet be invisible: a corrupt file decodes to
+ * fully transparent pixels, and near-black artwork vanishes on the dark theme.
+ * onError catches neither, so the decoded pixels are inspected once per host —
+ * blank icons fall back to the globe, dark ones get a light backing plate.
+ */
+type Verdict = 'ok' | 'dark' | 'blank';
+// Markdown remounts chips on every stream chunk; verdicts are keyed by host so
+// each icon pays the pixel scan once per session.
+const verdicts = new Map<string, Verdict>();
+
+function inspect(img: HTMLImageElement): Verdict {
+  const size = 16;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return 'ok';
+  let data: Uint8ClampedArray;
+  try {
+    ctx.drawImage(img, 0, 0, size, size);
+    data = ctx.getImageData(0, 0, size, size).data;
+  } catch {
+    return 'ok'; // undrawable or tainted — can't tell, keep the image
+  }
+  let opaque = 0;
+  let luma = 0;
+  for (let i = 0; i < data.length; i += 4) {
+    if (data[i + 3] < 16) continue;
+    opaque++;
+    luma += 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2];
+  }
+  if (opaque < size * size * 0.02) return 'blank';
+  return luma / opaque < 60 ? 'dark' : 'ok';
+}
+
 // The favicon is served by the main process over the atrium-favicon:// scheme
 // (see main/favicons.ts). A host with no icon 404s — swap in a neutral globe.
 function Favicon({ host }: { host: string }): React.JSX.Element {
-  const [failed, setFailed] = useState(false);
+  const [verdict, setVerdict] = useState<Verdict>(() => verdicts.get(host) ?? 'ok');
   const cls = 'mr-1 inline-block h-[0.95em] w-[0.95em] shrink-0 align-[-0.15em]';
-  if (failed) return <Globe className={`${cls} text-fg-tertiary`} aria-hidden />;
+  if (verdict === 'blank') return <Globe className={`${cls} text-fg-tertiary`} aria-hidden />;
+  const plate = verdict === 'dark' ? ' dark:bg-white/90 dark:p-px' : '';
   return (
     <img
       src={`atrium-favicon://${host}`}
       alt=""
       aria-hidden
       loading="lazy"
-      onError={() => setFailed(true)}
-      className={`${cls} rounded-[3px] object-contain`}
+      crossOrigin="anonymous"
+      onLoad={(e) => {
+        if (verdicts.has(host)) return;
+        const v = inspect(e.currentTarget);
+        verdicts.set(host, v);
+        setVerdict(v);
+      }}
+      onError={() => {
+        verdicts.set(host, 'blank');
+        setVerdict('blank');
+      }}
+      className={`${cls} rounded-[3px] object-contain${plate}`}
     />
   );
 }


### PR DESCRIPTION
## 问题

聊天里的链接 chip 有时显示一片空白(截图里的 Medium / UPX 行),虽然已有 Globe 兜底,但它只挂在 `onError` 上,而这两种情况图片都是「加载成功」的:

1. **损坏的 ICO**:medium.com 的 favicon.ico 被服务器用文本编码转过一遍(1898 个 U+FFFD 替换符,目录声明的图像大小 280MB vs 实际 8KB)。Chromium 宽容解码成 32x32 全透明图,`onload` 正常触发。
2. **暗色主题下的深色图标**:upx.github.io 回退到 github.io 的黑色章鱼猫,黑图标在暗色背景上不可见。

## 修复

**主进程 (`favicons.ts`)**
- 用 [decode-ico](https://github.com/LinusU/decode-ico) 校验 ICO 结构(解析失败即拒收;保留魔数前置判断,避免误杀放在 .ico 路径上的 PNG),让查找链继续走页面 `<link rel=icon>` / DDG 源 —— Medium 由此拿到了真图标而不是兜底
- 磁盘缓存加载时同样校验,已缓存的坏文件会被丢弃并重新解析
- scheme 开启 `corsEnabled` 并返回 `access-control-allow-origin`,渲染进程才能读像素

**渲染进程 (`LinkChip.tsx`)**
- 图标加载后画到 16x16 canvas 检查一次(结果按 host 缓存,流式重渲染不重复扫描):
  - 几乎全透明 → 视为无图标,显示 Globe
  - 平均亮度过低 → 暗色主题下垫白色圆角底板(Chrome 磁贴风格),亮色主题不受影响
- 彩色正常图标不受任何影响

## 验证

CDP 驱动真实应用实测(暗色主题):Medium 显示真实 M 图标(坏缓存被替换)、章鱼猫垫白底可见、CSDN 彩色图标无底板、不存在的域名显示 Globe;crossorigin 图片经自定义 scheme canvas 可读无 taint。`typecheck` / `lint` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)