### PR TITLE
fix(update): pre-stage update for instant restart, add pending button state

### DIFF
--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -51,10 +51,12 @@ class UpdaterManager {
 
     autoUpdater.logger = log;
     // Download a found update in the background so the dialog opens on progress
-    // or "ready to install". autoInstallOnAppQuit stays off so the swap only
-    // happens on an explicit Restart Now, never silently on quit.
+    // or "ready to install". autoInstallOnAppQuit must stay on: on macOS,
+    // turning it off defers Squirrel.Mac's staging (unzip + codesign verify) to
+    // the Restart Now click, freezing the button for a second. With it on the
+    // update is pre-staged, so restart is instant and a plain quit also installs.
     autoUpdater.autoDownload = true;
-    autoUpdater.autoInstallOnAppQuit = false;
+    autoUpdater.autoInstallOnAppQuit = true;
     autoUpdater.allowDowngrade = false;
 
     autoUpdater.on('checking-for-update', () => this.set({ stage: 'checking', error: null }));

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -181,9 +181,18 @@ export function UpdateDialog(): React.JSX.Element {
                 <button type="button" className={ghostBtn} onClick={closeDialog}>
                   {t('update.later')}
                 </button>
-                <button type="button" className={accentBtn} onClick={() => install.mutate()}>
-                  <RotateCw className="size-4" />
-                  {t('update.restartNow')}
+                <button
+                  type="button"
+                  className={accentBtn}
+                  disabled={install.isPending}
+                  onClick={() => install.mutate()}
+                >
+                  {install.isPending ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <RotateCw className="size-4" />
+                  )}
+                  {install.isPending ? t('update.restarting') : t('update.restartNow')}
                 </button>
               </>
             ) : stage === 'downloading' ? (

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -29,6 +29,7 @@ export const en: typeof zh = {
     downloading: 'Downloading…',
     downloadComplete: 'Download complete! Ready to install.',
     restartNow: 'Restart Now',
+    restarting: 'Restarting…',
     later: 'Later',
     failed: 'Update failed',
     retry: 'Retry',

--- a/src/renderer/src/i18n/zh.ts
+++ b/src/renderer/src/i18n/zh.ts
@@ -30,6 +30,7 @@ export const zh = {
     downloading: '下载中…',
     downloadComplete: '下载完成，重启即可安装。',
     restartNow: '立即重启',
+    restarting: '重启中…',
     later: '稍后',
     failed: '更新失败',
     retry: '重试',


### PR DESCRIPTION
## Why

Clicking **Restart Now** after an update download froze for 0.5–1s before the app closed. Root cause: with `autoInstallOnAppQuit = false`, electron-updater's `MacUpdater` defers native Squirrel.Mac staging (fetch from the local proxy + unzip + codesign verify) until `quitAndInstall()` is called — the whole staging cost lands on the button click.

## What

- **`autoInstallOnAppQuit = true`** — Squirrel pre-stages the update right after download, so Restart Now only performs the atomic swap and relaunch (instant). Semantic change: a plain quit (Cmd+Q) with a downloaded update now also installs it on exit, same as Slack/Chrome/VS Code.
- **Restart button pending state** — disabled + spinner + "Restarting…" while the install mutation is in flight. The mutation never resolves (the app quits), so the state holds until the window closes; it also covers clicking restart before staging finishes.
- New `update.restarting` i18n key (en/zh).

## Verification

`pnpm typecheck` and `biome check` pass on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)