### PR TITLE
fix(chat): fall through blank favicon.ico to the page-declared icon

### DIFF
--- a/src/main/favicons.ts
+++ b/src/main/favicons.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import decodeIco from 'decode-ico';
-import { app, protocol } from 'electron';
+import { app, nativeImage, protocol } from 'electron';
 import { parseHTML } from 'linkedom';
 import { createLogger } from './log';
 
@@ -133,6 +133,44 @@ function asImage(res: { bytes: Uint8Array<ArrayBuffer>; type: string | null }): 
   return ct ? { bytes: res.bytes, contentType: ct } : null;
 }
 
+// Share the renderer's "almost nothing opaque" threshold so both layers agree.
+const BLANK_OPAQUE_FRACTION = 0.02;
+function opaqueFraction(rgba: Uint8Array | Uint8ClampedArray): number {
+  const pixels = rgba.length / 4;
+  if (!pixels) return 1;
+  let opaque = 0;
+  for (let i = 3; i < rgba.length; i += 4) if (rgba[i] >= 16) opaque++;
+  return opaque / pixels;
+}
+
+/**
+ * A structurally valid icon can still be visually empty — a fully transparent
+ * placeholder that a browser would pass over in favour of the icon a page
+ * declares in <link rel=icon> (WordPress ships exactly such a default). Decode
+ * far enough to see whether any pixel is painted; an icon we can't decode (SVG,
+ * WebP) is assumed non-blank so a good icon is never dropped on a guess.
+ */
+function isBlank(bytes: Uint8Array): boolean {
+  if (bytes[0] === 0 && bytes[1] === 0 && bytes[2] === 1 && bytes[3] === 0) {
+    try {
+      const largest = decodeIco(bytes).sort((a, b) => b.width * b.height - a.width * a.height)[0];
+      return largest ? opaqueFraction(largest.data) < BLANK_OPAQUE_FRACTION : false;
+    } catch {
+      return false;
+    }
+  }
+  try {
+    const img = nativeImage.createFromBuffer(Buffer.from(bytes));
+    if (img.isEmpty()) return false;
+    // Electron's own types mis-declare getBitmap as void; it returns BGRA bytes,
+    // whose alpha lands at the same offset the opaque check reads.
+    const bitmap = img.getBitmap() as unknown as Buffer;
+    return opaqueFraction(bitmap) < BLANK_OPAQUE_FRACTION;
+  } catch {
+    return false;
+  }
+}
+
 // Pick the best-looking icon declared in the page head. Prefer scalable SVG,
 // then the highest-resolution raster (apple-touch-icons and sized <link>s),
 // falling back to the plain "icon"/"shortcut icon" defaults.
@@ -176,10 +214,11 @@ function pickIconHref(html: string, baseUrl: string): string | null {
 async function fromSite(host: string): Promise<Favicon | null> {
   // /favicon.ico first: one request, and for a ~16px chip its built-in low-res
   // variant is exactly right. Only parse the page HTML when it's missing, errors,
-  // or answers with something that isn't actually an image (SPA catch-all route).
+  // answers with something that isn't actually an image (SPA catch-all route),
+  // or hands back a blank placeholder that hides the real icon the page declares.
   const direct = await get(`https://${host}/favicon.ico`, MAX_ICON_BYTES);
   const directIcon = direct && asImage(direct);
-  if (directIcon) return directIcon;
+  if (directIcon && !isBlank(directIcon.bytes)) return directIcon;
 
   const page = await get(`https://${host}/`, MAX_HTML_BYTES);
   if (!page) return null;
@@ -187,7 +226,8 @@ async function fromSite(host: string): Promise<Favicon | null> {
   const iconUrl = pickIconHref(html, `https://${host}/`);
   if (!iconUrl) return null;
   const icon = await get(iconUrl, MAX_ICON_BYTES);
-  return icon ? asImage(icon) : null;
+  const declared = icon && asImage(icon);
+  return declared && !isBlank(declared.bytes) ? declared : null;
 }
 
 // DuckDuckGo's icon service — the privacy-respecting fallback for the many large
@@ -217,9 +257,9 @@ async function load(host: string): Promise<Favicon | null> {
     try {
       const raw = await readFile(path);
       const bytes = new Uint8Array(raw);
-      // A corrupt icon cached before validation existed must not be served
-      // forever — ignore it and re-resolve.
-      if (!isCorruptIco(bytes)) {
+      // A corrupt or blank icon cached before this validation existed must not
+      // be served forever — ignore it and re-resolve to the real icon.
+      if (!isCorruptIco(bytes) && !isBlank(bytes)) {
         const fav: Favicon = { bytes, contentType: sniff(raw) ?? 'image/x-icon' };
         mem.set(host, fav);
         return fav;


### PR DESCRIPTION
## 问题

你贴的 TechCrunch 文章链接抓不到 icon，但浏览器里明明有——根因是一类**新的**失败(和上个 PR 的"损坏 ICO"不同):

`techcrunch.com/favicon.ico` 是一张**结构完全合法、但 0% 不透明像素的透明占位图**(WordPress 默认给的,198 字节)。`decode-ico` 能正常解析它、content-type 也对,所以 `fromSite` 在第一步 `/favicon.ico` 就"成功"返回它,**根本不会去解析页面里 `<link rel=icon>` 指向的那张真正的渐变 logo**。渲染进程的 `inspect` 顶多把它判空显示 Globe,但真图标明明存在。

这正是和 Chrome 的行为差异:Chrome 以 HTML 声明的 `<link rel=icon>` 为主源,`/favicon.ico` 只是没声明时的兜底;我们为省一次请求把顺序倒了,于是被占位图截胡。

## 修复

保留"`/favicon.ico` 优先"的优化,但**只在它是真图标(非空白)时才接受**;若是空白占位图,就按浏览器的做法回退到页面声明的 `<link>`。

- `isBlank`:把图标解码到能判断"有没有像素被画上"的程度 —— ICO 用已有的 `decode-ico`,栅格图(PNG/JPEG)用 Electron `nativeImage`;无法解码的格式(SVG/WebP)一律视为非空,绝不凭猜丢掉好图标。阈值(不透明像素 < 2%)与渲染进程 `inspect` 一致。
- `fromSite`:空白的 `/favicon.ico` 跳过,改取页面 `<link>` 声明的图标。
- `load()`:修复前已缓存的空白占位图,和损坏 ICO 一样对待 —— 下次加载自动跳过并重新解析成真图标(你机器上 techcrunch 的旧缓存就是这样自愈的)。

## 验证

CDP 驱动真实应用(暗色主题)实测:
- **scheme 像素探针**:`techcrunch.com` 从 0% 不透明的空白图,变成 **192×192、100% 不透明、17 种颜色的真实渐变 logo**;`load()` 自愈路径(空白缓存→跳过→重解析)确认生效。
- **LinkChip 渲染 + 截图**:TechCrunch 显示标志性的绿色 "TC" 图标,GitHub / Medium 正常。

`typecheck` / `lint` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
