### PR TITLE
feat(providers): add volcengine agent plan and coding plan providers

### DIFF
--- a/src/main/providers/manifest.test.ts
+++ b/src/main/providers/manifest.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'bun:test';
+import { anthropicApiBase } from './manifest';
+
+test('appends /v1 to vendor-documented bases', () => {
+  expect(anthropicApiBase('https://ark.cn-beijing.volces.com/api/plan')).toBe(
+    'https://ark.cn-beijing.volces.com/api/plan/v1',
+  );
+  expect(anthropicApiBase('https://api.moonshot.cn/anthropic')).toBe(
+    'https://api.moonshot.cn/anthropic/v1',
+  );
+  expect(anthropicApiBase('https://api.anthropic.com')).toBe('https://api.anthropic.com/v1');
+});
+
+test('keeps bases that already end in /v1', () => {
+  expect(anthropicApiBase('https://aihubmix.com/v1')).toBe('https://aihubmix.com/v1');
+});
+
+test('strips trailing slashes before deciding', () => {
+  expect(anthropicApiBase('https://api.anthropic.com/v1/')).toBe('https://api.anthropic.com/v1');
+  expect(anthropicApiBase('https://api.moonshot.cn/anthropic/')).toBe(
+    'https://api.moonshot.cn/anthropic/v1',
+  );
+});

--- a/src/main/providers/manifest.ts
+++ b/src/main/providers/manifest.ts
@@ -175,6 +175,31 @@ export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
     ],
   },
   {
+    id: 'volcengine-coding',
+    kind: 'cloud-api',
+    name: 'Volcengine Coding Plan',
+    descriptionKey: 'settings.providers.desc.volcengineCoding',
+    protocol: 'anthropic',
+    defaultBaseUrl: 'https://ark.cn-beijing.volces.com/api/coding',
+    consoleUrl:
+      'https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement?LLM=%7B%7D&advancedActiveKey=subscribe',
+    // Like the agent plan: no model-listing API, doc's text-generation set.
+    models: [
+      'ark-code-latest',
+      'doubao-seed-code',
+      'doubao-seed-2.0-code',
+      'doubao-seed-2.0-lite',
+      'doubao-seed-2.0-pro',
+      'deepseek-v4-flash',
+      'deepseek-v4-pro',
+      'minimax-m2.7',
+      'minimax-m3',
+      'glm-5.2',
+      'kimi-k2.6',
+      'kimi-k2.7-code',
+    ],
+  },
+  {
     id: 'openrouter',
     kind: 'cloud-api',
     name: 'OpenRouter',

--- a/src/main/providers/manifest.ts
+++ b/src/main/providers/manifest.ts
@@ -149,6 +149,18 @@ export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
     models: ['glm-4.6'],
   },
   {
+    id: 'volcengine-agent',
+    kind: 'cloud-api',
+    name: 'Volcengine Agent Plan',
+    descriptionKey: 'settings.providers.desc.volcengineAgent',
+    protocol: 'anthropic',
+    defaultBaseUrl: 'https://ark.cn-beijing.volces.com/api/plan',
+    consoleUrl:
+      'https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement?LLM=%7B%7D&advancedActiveKey=agentPlan',
+    // The plan endpoint has no model-listing API; this is the doc's supported set.
+    models: ['ark-code-latest', 'kimi-k2.6', 'glm-5.2', 'minimax-m2.7'],
+  },
+  {
     id: 'openrouter',
     kind: 'cloud-api',
     name: 'OpenRouter',

--- a/src/main/providers/manifest.ts
+++ b/src/main/providers/manifest.ts
@@ -14,6 +14,18 @@ export type ProviderKind = 'cloud-api' | 'local-cli' | 'local-service';
 export type CloudApiProtocol = 'anthropic' | 'openai-compatible' | 'google-gemini';
 
 /**
+ * @ai-sdk/anthropic requests `${baseURL}/messages`, so it needs a base that
+ * already contains the `/v1` segment — but vendors advertise their
+ * Anthropic-compatible bases without it (Claude Code appends `/v1/messages`
+ * itself), and users paste those documented URLs. Accept both shapes by
+ * appending `/v1` unless the base already ends with it.
+ */
+export function anthropicApiBase(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, '');
+  return trimmed.endsWith('/v1') ? trimmed : `${trimmed}/v1`;
+}
+
+/**
  * How to launch a local CLI as an ACP agent. Some CLIs speak ACP natively (run
  * their own binary); others need the official ACP adapter package, whose bin we
  * resolve from node_modules.

--- a/src/main/providers/manifest.ts
+++ b/src/main/providers/manifest.ts
@@ -157,8 +157,22 @@ export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
     defaultBaseUrl: 'https://ark.cn-beijing.volces.com/api/plan',
     consoleUrl:
       'https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement?LLM=%7B%7D&advancedActiveKey=agentPlan',
-    // The plan endpoint has no model-listing API; this is the doc's supported set.
-    models: ['ark-code-latest', 'kimi-k2.6', 'glm-5.2', 'minimax-m2.7'],
+    // The plan endpoint has no model-listing API; this is the doc's supported
+    // text-generation set (each id verified against the live endpoint).
+    models: [
+      'ark-code-latest',
+      'doubao-seed-2.0-mini',
+      'doubao-seed-2.0-lite',
+      'doubao-seed-2.0-code',
+      'doubao-seed-2.0-pro',
+      'deepseek-v4-flash',
+      'deepseek-v4-pro',
+      'minimax-m2.7',
+      'minimax-m3',
+      'glm-5.2',
+      'kimi-k2.6',
+      'kimi-k2.7-code',
+    ],
   },
   {
     id: 'openrouter',

--- a/src/main/providers/model-fetcher.ts
+++ b/src/main/providers/model-fetcher.ts
@@ -1,4 +1,4 @@
-import type { CloudApiProtocol } from './manifest';
+import { anthropicApiBase, type CloudApiProtocol } from './manifest';
 
 /**
  * Fetch the available model id list from a cloud provider's `/models`-style
@@ -26,7 +26,7 @@ export async function fetchModelIds(args: {
 }
 
 async function fetchAnthropic(baseUrl: string, apiKey: string): Promise<string[]> {
-  const res = await fetch(`${baseUrl}/v1/models`, {
+  const res = await fetch(`${anthropicApiBase(baseUrl)}/models`, {
     headers: {
       'x-api-key': apiKey,
       'anthropic-version': '2023-06-01',

--- a/src/main/providers/resolve.ts
+++ b/src/main/providers/resolve.ts
@@ -8,7 +8,12 @@ import { isImageModel, modelCapabilities } from '../agent/models/catalog';
 import type { Db } from '../db';
 import { providers } from '../db/schema';
 import { decryptCredentials } from './credentials';
-import { getProviderManifest, type LocalServiceManifest, type ProviderManifest } from './manifest';
+import {
+  anthropicApiBase,
+  getProviderManifest,
+  type LocalServiceManifest,
+  type ProviderManifest,
+} from './manifest';
 
 type CloudManifest = Extract<ProviderManifest, { kind: 'cloud-api' }>;
 type ProviderConn = { manifest: CloudManifest; apiKey: string; baseURL: string };
@@ -61,7 +66,7 @@ export function resolveModel(db: Db, providerId: string, modelId: string): Langu
   const { manifest, apiKey, baseURL } = providerConn(db, providerId);
   switch (manifest.protocol) {
     case 'anthropic':
-      return createAnthropic({ apiKey, baseURL })(modelId);
+      return createAnthropic({ apiKey, baseURL: anthropicApiBase(baseURL) })(modelId);
     case 'openai-compatible':
       return createOpenAICompatible({ name: providerId, apiKey, baseURL })(modelId);
     case 'google-gemini':

--- a/src/renderer/src/components/settings/providers/ProviderDetail.tsx
+++ b/src/renderer/src/components/settings/providers/ProviderDetail.tsx
@@ -73,6 +73,9 @@ function CloudApiForm({
     fetchedModels?: string[];
     enabledModels?: string[];
   };
+  // Manifest models are the curated floor — some providers (coding/agent
+  // plans) expose no listing endpoint, so fetch results only extend them.
+  const models = [...new Set([...provider.models, ...(config.fetchedModels ?? [])])];
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-5">
       <ApiKeyField
@@ -93,7 +96,7 @@ function CloudApiForm({
             ? t('settings.providers.fetchHint')
             : t('settings.providers.fetchHintNoKey')
         }
-        models={config.fetchedModels ?? []}
+        models={models}
         enabledModels={config.enabledModels ?? []}
       />
     </div>

--- a/src/renderer/src/components/settings/providers/ProviderIcon.tsx
+++ b/src/renderer/src/components/settings/providers/ProviderIcon.tsx
@@ -30,6 +30,7 @@ const SVG_BY_ID: Record<string, string> = {
   'kimi-coding': kimiSvg,
   'zai-coding': zhipuSvg,
   'volcengine-agent': volcengineSvg,
+  'volcengine-coding': volcengineSvg,
   openrouter: openrouterSvg,
   aihubmix: aihubmixSvg,
   'claude-code': claudecodeSvg,

--- a/src/renderer/src/components/settings/providers/ProviderIcon.tsx
+++ b/src/renderer/src/components/settings/providers/ProviderIcon.tsx
@@ -10,6 +10,7 @@ import moonshotSvg from '@lobehub/icons-static-svg/icons/moonshot.svg?raw';
 import ollamaSvg from '@lobehub/icons-static-svg/icons/ollama.svg?raw';
 import openaiSvg from '@lobehub/icons-static-svg/icons/openai.svg?raw';
 import openrouterSvg from '@lobehub/icons-static-svg/icons/openrouter.svg?raw';
+import volcengineSvg from '@lobehub/icons-static-svg/icons/volcengine-color.svg?raw';
 import zhipuSvg from '@lobehub/icons-static-svg/icons/zhipu-color.svg?raw';
 
 /**
@@ -28,6 +29,7 @@ const SVG_BY_ID: Record<string, string> = {
   moonshot: moonshotSvg,
   'kimi-coding': kimiSvg,
   'zai-coding': zhipuSvg,
+  'volcengine-agent': volcengineSvg,
   openrouter: openrouterSvg,
   aihubmix: aihubmixSvg,
   'claude-code': claudecodeSvg,

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -618,6 +618,7 @@ export const en: typeof zh = {
         moonshot: 'Kimi family (Moonshot AI). Long context.',
         kimiCoding: 'Moonshot · Coding subscription (Anthropic-compatible).',
         zaiCoding: 'Zhipu GLM Coding subscription (Anthropic-compatible).',
+        volcengineAgent: 'Volcengine Ark · Agent Plan subscription (Anthropic-compatible).',
         openrouter: 'One API that routes to 300+ models.',
         aihubmix: 'One-stop LLM aggregator — one key, many models.',
         claudeCode:

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -619,6 +619,7 @@ export const en: typeof zh = {
         kimiCoding: 'Moonshot · Coding subscription (Anthropic-compatible).',
         zaiCoding: 'Zhipu GLM Coding subscription (Anthropic-compatible).',
         volcengineAgent: 'Volcengine Ark · Agent Plan subscription (Anthropic-compatible).',
+        volcengineCoding: 'Volcengine Ark · Coding Plan subscription (Anthropic-compatible).',
         openrouter: 'One API that routes to 300+ models.',
         aihubmix: 'One-stop LLM aggregator — one key, many models.',
         claudeCode:

--- a/src/renderer/src/i18n/zh.ts
+++ b/src/renderer/src/i18n/zh.ts
@@ -607,6 +607,7 @@ export const zh = {
         kimiCoding: '月之暗面 · Coding 订阅版（Anthropic 兼容）。',
         zaiCoding: '智谱清言 GLM Coding 订阅版（Anthropic 兼容）。',
         volcengineAgent: '火山方舟 · Agent Plan 订阅版（Anthropic 兼容）。',
+        volcengineCoding: '火山方舟 · Coding Plan 订阅版（Anthropic 兼容）。',
         openrouter: '统一 API 路由 300+ 模型。',
         aihubmix: '一站式 LLM 聚合，单 key 调多家模型。',
         claudeCode: '通过 ACP 调用你本地已登录的 Claude Code（复用订阅，无需 API key）。',

--- a/src/renderer/src/i18n/zh.ts
+++ b/src/renderer/src/i18n/zh.ts
@@ -606,6 +606,7 @@ export const zh = {
         moonshot: 'Kimi 系列（Moonshot AI）。长上下文。',
         kimiCoding: '月之暗面 · Coding 订阅版（Anthropic 兼容）。',
         zaiCoding: '智谱清言 GLM Coding 订阅版（Anthropic 兼容）。',
+        volcengineAgent: '火山方舟 · Agent Plan 订阅版（Anthropic 兼容）。',
         openrouter: '统一 API 路由 300+ 模型。',
         aihubmix: '一站式 LLM 聚合，单 key 调多家模型。',
         claudeCode: '通过 ACP 调用你本地已登录的 Claude Code（复用订阅，无需 API key）。',


### PR DESCRIPTION
## What

Adds **Volcengine Agent Plan**(火山方舟 Agent Plan)as a cloud provider, using its Anthropic-compatible endpoint (`https://ark.cn-beijing.volces.com/api/plan`), following the Kimi/Z.AI coding-plan pattern.

- Manifest entry with the documented text-generation model set (12 ids: `ark-code-latest` alias, `doubao-seed-2.0-mini/lite/code/pro`, `deepseek-v4-flash/pro`, `minimax-m2.7`/`m3`, `glm-5.2`, `kimi-k2.6`/`k2.7-code`) — every id verified against the live API
- Provider icon (`volcengine-color.svg` from lobehub), zh/en descriptions

## Also: Volcengine Coding Plan

The Coding Plan is a **separate subscription** with its own key domain and endpoint (`api/coding` vs `api/plan` — verified live: routes exist, agent-plan keys are rejected with 401). Added as a second provider (`volcengine-coding`) with the plan's documented model set: same families minus `doubao-seed-2.0-mini`, plus `doubao-seed-code`. Chat not E2E-tested (no Coding Plan key on hand), but protocol, endpoint shape, and the `/v1` normalization path are identical to the verified agent plan.

## Latent bug fixed along the way

`@ai-sdk/anthropic` requests `${baseURL}/messages` (its default base already contains `/v1`), but our manifests store vendor-documented bases **without** `/v1` — those are Claude-Code-style bases (Claude Code appends `/v1/messages` itself). Verified against live endpoints:

| base + `/messages` | status |
|---|---|
| `api.anthropic.com/messages` | 404 |
| `api.moonshot.cn/anthropic/messages` (Kimi Coding Plan) | 404 |
| `ark.cn-beijing.volces.com/api/plan/messages` | 401 |

New `anthropicApiBase()` helper appends `/v1` unless the base already ends with it (so existing SDK-shaped user configs like `aihubmix.com/v1` are untouched), shared by chat resolution and the model-listing fetcher. Unit-tested.

## Models block: manifest models as the floor

The Ark plan endpoint has **no model-listing API** (`/v1/models` 404s), so `Fetch` can never populate the list. The settings models block now unions the manifest's static models with fetched ones — coding/agent-plan providers show a usable toggle list out of the box. (Previously the manifest `models` field was dead data — kimi-coding/zai-coding relied entirely on Fetch.)

## Tested

- `bun test` 505 pass, typecheck + biome clean
- E2E in the dev app via CDP: configured the real Agent Plan key, enabled `ark-code-latest`, sent a chat — streaming reply + thinking block rendered correctly; tool-use verified via raw API (`tool_use` + `thinking` blocks come through the Anthropic protocol)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

