### PR TITLE
fix(models): carry vendor model metadata in the provider manifest

### DIFF
--- a/src/main/agent/models/lookup.test.ts
+++ b/src/main/agent/models/lookup.test.ts
@@ -92,13 +92,32 @@ test('capabilitiesFrom marks image output from mode even without output modaliti
   ]);
 });
 
-test('manifest-declared metadata covers ark plan ids the litellm dataset misses', () => {
+test('manifest-declared metadata covers ids the litellm dataset misses', () => {
   expect(maxContextTokensFrom(catalog, 'ark-code-latest')).toBe(200_000);
-  expect(maxContextTokensFrom(catalog, 'doubao-seed-2.0-code')).toBe(262_144);
-  expect(capabilitiesFrom(catalog, 'doubao-seed-2.0-pro').vision).toBe(true);
   expect(capabilitiesFrom(catalog, 'ark-code-latest').toolCall).toBe(true);
-  // vendor prefix + casing resolve through the same bare-name join
-  expect(maxContextTokensFrom(catalog, 'volcengine/Doubao-Seed-2.0-Lite')).toBe(262_144);
+  expect(maxContextTokensFrom(catalog, 'doubao-seed-code')).toBe(262_144);
+  expect(capabilitiesFrom(catalog, 'doubao-seed-code').vision).toBe(true);
+});
+
+test('a manifest catalogId alias resolves the version-pinned litellm key', () => {
+  const withPinned: ModelsCatalog = {
+    sample_spec: {},
+    'volcengine/doubao-seed-2-0-code-preview-260215': {
+      max_input_tokens: 256_000,
+      max_output_tokens: 128_000,
+      supports_vision: true,
+    },
+    'volcengine/doubao-seed-2-0-lite-260215': { max_input_tokens: 256_000 },
+  };
+  expect(maxContextTokensFrom(withPinned, 'doubao-seed-2.0-code')).toBe(256_000);
+  expect(capabilitiesFrom(withPinned, 'doubao-seed-2.0-code').vision).toBe(true);
+  // vendor prefix + casing on the serving id resolve through the same alias
+  expect(maxContextTokensFrom(withPinned, 'volcengine/Doubao-Seed-2.0-Lite')).toBe(256_000);
+});
+
+test('an alias whose litellm key vanished degrades to the conservative fallback', () => {
+  // doubao-seed-2.0-pro declares only a catalogId; absent from this catalog
+  expect(maxContextTokensFrom(catalog, 'doubao-seed-2.0-pro')).toBe(FALLBACK_CONTEXT_TOKENS);
 });
 
 test('manifest-declared fields override a litellm entry, undeclared fields survive', () => {

--- a/src/main/agent/models/lookup.test.ts
+++ b/src/main/agent/models/lookup.test.ts
@@ -91,6 +91,23 @@ test('capabilitiesFrom marks image output from mode even without output modaliti
   ]);
 });
 
+test('the supplement covers ark plan ids the litellm dataset misses', () => {
+  expect(maxContextTokensFrom(catalog, 'ark-code-latest')).toBe(200_000);
+  expect(maxContextTokensFrom(catalog, 'doubao-seed-2.0-code')).toBe(262_144);
+  expect(capabilitiesFrom(catalog, 'doubao-seed-2.0-pro').vision).toBe(true);
+  expect(capabilitiesFrom(catalog, 'ark-code-latest').toolCall).toBe(true);
+  // vendor prefix + casing resolve through the same bare-name join
+  expect(maxContextTokensFrom(catalog, 'volcengine/Doubao-Seed-2.0-Lite')).toBe(262_144);
+});
+
+test('a litellm entry beats the supplement', () => {
+  const withUpstream: ModelsCatalog = {
+    sample_spec: {},
+    'volcengine/ark-code-latest': { max_input_tokens: 999 },
+  };
+  expect(maxContextTokensFrom(withUpstream, 'ark-code-latest')).toBe(999);
+});
+
 test('capabilitiesFrom defaults conservatively for an unknown id', () => {
   const caps = capabilitiesFrom(catalog, 'no-such-model');
   expect(caps.vision).toBe(false);

--- a/src/main/agent/models/lookup.test.ts
+++ b/src/main/agent/models/lookup.test.ts
@@ -4,6 +4,7 @@ import {
   FALLBACK_CONTEXT_TOKENS,
   findModelInfo,
   maxContextTokensFrom,
+  modelPricingFrom,
 } from './lookup';
 import type { ModelsCatalog } from './types';
 
@@ -91,7 +92,7 @@ test('capabilitiesFrom marks image output from mode even without output modaliti
   ]);
 });
 
-test('the supplement covers ark plan ids the litellm dataset misses', () => {
+test('manifest-declared metadata covers ark plan ids the litellm dataset misses', () => {
   expect(maxContextTokensFrom(catalog, 'ark-code-latest')).toBe(200_000);
   expect(maxContextTokensFrom(catalog, 'doubao-seed-2.0-code')).toBe(262_144);
   expect(capabilitiesFrom(catalog, 'doubao-seed-2.0-pro').vision).toBe(true);
@@ -100,12 +101,15 @@ test('the supplement covers ark plan ids the litellm dataset misses', () => {
   expect(maxContextTokensFrom(catalog, 'volcengine/Doubao-Seed-2.0-Lite')).toBe(262_144);
 });
 
-test('a litellm entry beats the supplement', () => {
+test('manifest-declared fields override a litellm entry, undeclared fields survive', () => {
   const withUpstream: ModelsCatalog = {
     sample_spec: {},
-    'volcengine/ark-code-latest': { max_input_tokens: 999 },
+    'volcengine/ark-code-latest': { max_input_tokens: 999, input_cost_per_token: 5 },
   };
-  expect(maxContextTokensFrom(withUpstream, 'ark-code-latest')).toBe(999);
+  // the vendor-documented window wins over litellm's bare-name variant…
+  expect(maxContextTokensFrom(withUpstream, 'ark-code-latest')).toBe(200_000);
+  // …while fields the manifest doesn't declare still come from litellm
+  expect(modelPricingFrom(withUpstream, 'ark-code-latest').input).toBe(5);
 });
 
 test('capabilitiesFrom defaults conservatively for an unknown id', () => {

--- a/src/main/agent/models/lookup.ts
+++ b/src/main/agent/models/lookup.ts
@@ -29,11 +29,14 @@ function declaredInfo(model: ManifestModel): ModelInfo | undefined {
  * entry, while undeclared fields still resolve through it.
  */
 const MANIFEST_OVERLAY: Record<string, ModelInfo> = {};
+/** Vendor serving id (bare) → the litellm key its metadata lives under. */
+const MANIFEST_CATALOG_ID: Record<string, string> = {};
 for (const provider of PROVIDER_MANIFEST) {
   if (provider.kind !== 'cloud-api') continue;
   for (const model of provider.models) {
     const info = declaredInfo(model);
     if (info) MANIFEST_OVERLAY[bareName(model.id)] = info;
+    if (model.catalogId) MANIFEST_CATALOG_ID[bareName(model.id)] = model.catalogId;
   }
 }
 
@@ -51,6 +54,11 @@ export function findModelInfo(catalog: ModelsCatalog, modelId: string): ModelInf
   if (modelId === 'sample_spec' || target === 'sample_spec') return undefined;
 
   let fromCatalog = catalog[modelId];
+  if (!fromCatalog) {
+    // A manifest-declared alias beats the scan: it names the exact litellm key.
+    const aliasKey = MANIFEST_CATALOG_ID[target];
+    if (aliasKey) fromCatalog = catalog[aliasKey];
+  }
   if (!fromCatalog) {
     for (const [key, info] of Object.entries(catalog)) {
       if (key !== 'sample_spec' && bareName(key) === target) {

--- a/src/main/agent/models/lookup.ts
+++ b/src/main/agent/models/lookup.ts
@@ -11,6 +11,41 @@ const toModalities = (list?: string[]): Modality[] =>
 const bareName = (id: string): string => id.slice(id.lastIndexOf('/') + 1).toLowerCase();
 
 /**
+ * Vendor-documented entries for ids the litellm dataset doesn't carry — the
+ * Volcengine Ark plan models. Without a window the UI's context gauge and the
+ * compaction threshold fall back to 128k, half these models' real size.
+ * Consulted only on a catalog miss, so a litellm entry that lands upstream
+ * later wins automatically.
+ */
+const CATALOG_SUPPLEMENT: Record<string, ModelInfo> = {
+  // Auto-dispatch alias; sized to the smallest window in its dispatch pool.
+  'ark-code-latest': {
+    max_input_tokens: 200_000,
+    max_output_tokens: 131_072,
+    supports_function_calling: true,
+    supports_reasoning: true,
+  },
+  'doubao-seed-code': {
+    max_input_tokens: 262_144,
+    supports_vision: true,
+    supports_function_calling: true,
+    supports_reasoning: true,
+  },
+  ...Object.fromEntries(
+    ['mini', 'lite', 'code', 'pro'].map((tier) => [
+      `doubao-seed-2.0-${tier}`,
+      {
+        max_input_tokens: 262_144,
+        max_output_tokens: 131_072,
+        supports_vision: true,
+        supports_function_calling: true,
+        supports_reasoning: true,
+      } satisfies ModelInfo,
+    ]),
+  ),
+};
+
+/**
  * Resolve a model id to its litellm entry. An exact key hit wins; otherwise we
  * match on the bare model name (last `/`-segment, case-insensitive). Relays and
  * aggregators rewrite the prefix and casing freely — litellm keys Kimi as
@@ -26,7 +61,7 @@ export function findModelInfo(catalog: ModelsCatalog, modelId: string): ModelInf
   for (const [key, info] of Object.entries(catalog)) {
     if (key !== 'sample_spec' && bareName(key) === target) return info;
   }
-  return undefined;
+  return CATALOG_SUPPLEMENT[target];
 }
 
 export function maxContextTokensFrom(catalog: ModelsCatalog, modelId: string): number {

--- a/src/main/agent/models/lookup.ts
+++ b/src/main/agent/models/lookup.ts
@@ -1,3 +1,4 @@
+import { type ManifestModel, PROVIDER_MANIFEST } from '../../providers/manifest';
 import type { Modality, ModelCapabilities, ModelInfo, ModelPricing, ModelsCatalog } from './types';
 
 /** Conservative window for ids the dataset doesn't know — compact early, never overflow. */
@@ -10,40 +11,31 @@ const toModalities = (list?: string[]): Modality[] =>
 /** The bare model name: the segment after the last `/`, lowercased. */
 const bareName = (id: string): string => id.slice(id.lastIndexOf('/') + 1).toLowerCase();
 
+function declaredInfo(model: ManifestModel): ModelInfo | undefined {
+  const info: ModelInfo = {};
+  if (model.contextTokens != null) info.max_input_tokens = model.contextTokens;
+  if (model.outputTokens != null) info.max_output_tokens = model.outputTokens;
+  if (model.vision != null) info.supports_vision = model.vision;
+  if (model.toolCall != null) info.supports_function_calling = model.toolCall;
+  if (model.reasoning != null) info.supports_reasoning = model.reasoning;
+  return Object.keys(info).length > 0 ? info : undefined;
+}
+
 /**
- * Vendor-documented entries for ids the litellm dataset doesn't carry — the
- * Volcengine Ark plan models. Without a window the UI's context gauge and the
- * compaction threshold fall back to 128k, half these models' real size.
- * Consulted only on a catalog miss, so a litellm entry that lands upstream
- * later wins automatically.
+ * Metadata declared on the provider manifest's models, keyed by bare name.
+ * A declaration is the vendor's documented truth for the exact endpoint we
+ * ship — litellm's bare-name join can miss (Ark plan ids) or land on another
+ * vendor's variant of the same model — so declared fields override the litellm
+ * entry, while undeclared fields still resolve through it.
  */
-const CATALOG_SUPPLEMENT: Record<string, ModelInfo> = {
-  // Auto-dispatch alias; sized to the smallest window in its dispatch pool.
-  'ark-code-latest': {
-    max_input_tokens: 200_000,
-    max_output_tokens: 131_072,
-    supports_function_calling: true,
-    supports_reasoning: true,
-  },
-  'doubao-seed-code': {
-    max_input_tokens: 262_144,
-    supports_vision: true,
-    supports_function_calling: true,
-    supports_reasoning: true,
-  },
-  ...Object.fromEntries(
-    ['mini', 'lite', 'code', 'pro'].map((tier) => [
-      `doubao-seed-2.0-${tier}`,
-      {
-        max_input_tokens: 262_144,
-        max_output_tokens: 131_072,
-        supports_vision: true,
-        supports_function_calling: true,
-        supports_reasoning: true,
-      } satisfies ModelInfo,
-    ]),
-  ),
-};
+const MANIFEST_OVERLAY: Record<string, ModelInfo> = {};
+for (const provider of PROVIDER_MANIFEST) {
+  if (provider.kind !== 'cloud-api') continue;
+  for (const model of provider.models) {
+    const info = declaredInfo(model);
+    if (info) MANIFEST_OVERLAY[bareName(model.id)] = info;
+  }
+}
 
 /**
  * Resolve a model id to its litellm entry. An exact key hit wins; otherwise we
@@ -52,16 +44,24 @@ const CATALOG_SUPPLEMENT: Record<string, ModelInfo> = {
  * `moonshot/kimi-k2.5`, while a relay serves `moonshotai/Kimi-K2.5` — so the
  * stable join key is the model name, not the vendor path. Same-name entries
  * across providers are the same model, so the first match's capabilities apply.
+ * Fields declared in the provider manifest overlay whatever litellm has.
  */
 export function findModelInfo(catalog: ModelsCatalog, modelId: string): ModelInfo | undefined {
-  if (modelId !== 'sample_spec' && catalog[modelId]) return catalog[modelId];
-
   const target = bareName(modelId);
-  if (target === 'sample_spec') return undefined;
-  for (const [key, info] of Object.entries(catalog)) {
-    if (key !== 'sample_spec' && bareName(key) === target) return info;
+  if (modelId === 'sample_spec' || target === 'sample_spec') return undefined;
+
+  let fromCatalog = catalog[modelId];
+  if (!fromCatalog) {
+    for (const [key, info] of Object.entries(catalog)) {
+      if (key !== 'sample_spec' && bareName(key) === target) {
+        fromCatalog = info;
+        break;
+      }
+    }
   }
-  return CATALOG_SUPPLEMENT[target];
+  const declared = MANIFEST_OVERLAY[target];
+  if (fromCatalog && declared) return { ...fromCatalog, ...declared };
+  return declared ?? fromCatalog;
 }
 
 export function maxContextTokensFrom(catalog: ModelsCatalog, modelId: string): number {

--- a/src/main/providers/manifest.ts
+++ b/src/main/providers/manifest.ts
@@ -35,14 +35,17 @@ export type AcpLaunch =
   | { via: 'adapter'; package: string; bin: string };
 
 /**
- * A model in a provider's curated catalog. The metadata fields are the
- * vendor's documented facts for the exact endpoint we ship; anything declared
- * here overrides the litellm catalog's bare-name, cross-provider guess (see
- * agent/models/lookup.ts). Declare only what the vendor states — undeclared
- * fields still resolve through litellm.
+ * A model in a provider's curated catalog. `catalogId` maps the vendor's
+ * serving id to the litellm catalog key that carries its metadata, for when
+ * the two spellings differ (litellm pins versions: `doubao-seed-2.0-code` is
+ * keyed `volcengine/doubao-seed-2-0-code-preview-260215`). The remaining
+ * fields are vendor-documented facts for ids litellm doesn't carry at all;
+ * anything declared overrides the litellm entry, undeclared fields still
+ * resolve through it (see agent/models/lookup.ts).
  */
 export type ManifestModel = {
   id: string;
+  catalogId?: string;
   contextTokens?: number;
   outputTokens?: number;
   vision?: boolean;
@@ -93,19 +96,19 @@ export type LocalServiceManifest = {
 export type ProviderManifest = CloudApiManifest | LocalCliManifest | LocalServiceManifest;
 
 /**
- * Ark plan models missing from the litellm dataset — without declared windows
- * the context gauge and compaction threshold would fall back to 128k, half the
- * documented size. Doc: 256k context / 128k output, vision, thinking-capable.
+ * The Ark plans serve the doubao-seed-2.0 family under bare ids while litellm
+ * keys them version-pinned, so the bare-name join misses; map to the litellm
+ * keys so window/capability/pricing data flows from the catalog.
  */
-const DOUBAO_SEED_2_META = {
-  contextTokens: 262_144,
-  outputTokens: 131_072,
-  vision: true,
-  toolCall: true,
-  reasoning: true,
-} as const;
+const DOUBAO_SEED_2 = {
+  mini: { id: 'doubao-seed-2.0-mini', catalogId: 'volcengine/doubao-seed-2-0-mini-260215' },
+  lite: { id: 'doubao-seed-2.0-lite', catalogId: 'volcengine/doubao-seed-2-0-lite-260215' },
+  code: { id: 'doubao-seed-2.0-code', catalogId: 'volcengine/doubao-seed-2-0-code-preview-260215' },
+  pro: { id: 'doubao-seed-2.0-pro', catalogId: 'volcengine/doubao-seed-2-0-pro-260215' },
+} satisfies Record<string, ManifestModel>;
 
-// Auto-dispatch alias; sized to the smallest window in its dispatch pool.
+// Auto-dispatch alias litellm can't know; sized to the smallest window in its
+// dispatch pool.
 const ARK_CODE_LATEST: ManifestModel = {
   id: 'ark-code-latest',
   contextTokens: 200_000,
@@ -199,10 +202,10 @@ export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
     // text-generation set (each id verified against the live endpoint).
     models: [
       ARK_CODE_LATEST,
-      { id: 'doubao-seed-2.0-mini', ...DOUBAO_SEED_2_META },
-      { id: 'doubao-seed-2.0-lite', ...DOUBAO_SEED_2_META },
-      { id: 'doubao-seed-2.0-code', ...DOUBAO_SEED_2_META },
-      { id: 'doubao-seed-2.0-pro', ...DOUBAO_SEED_2_META },
+      DOUBAO_SEED_2.mini,
+      DOUBAO_SEED_2.lite,
+      DOUBAO_SEED_2.code,
+      DOUBAO_SEED_2.pro,
       { id: 'deepseek-v4-flash' },
       { id: 'deepseek-v4-pro' },
       { id: 'minimax-m2.7' },
@@ -224,6 +227,7 @@ export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
     // Like the agent plan: no model-listing API, doc's text-generation set.
     models: [
       ARK_CODE_LATEST,
+      // Retired from litellm's dataset; vendor doc: 256k window, multimodal.
       {
         id: 'doubao-seed-code',
         contextTokens: 262_144,
@@ -231,9 +235,9 @@ export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
         toolCall: true,
         reasoning: true,
       },
-      { id: 'doubao-seed-2.0-code', ...DOUBAO_SEED_2_META },
-      { id: 'doubao-seed-2.0-lite', ...DOUBAO_SEED_2_META },
-      { id: 'doubao-seed-2.0-pro', ...DOUBAO_SEED_2_META },
+      DOUBAO_SEED_2.code,
+      DOUBAO_SEED_2.lite,
+      DOUBAO_SEED_2.pro,
       { id: 'deepseek-v4-flash' },
       { id: 'deepseek-v4-pro' },
       { id: 'minimax-m2.7' },

--- a/src/main/providers/manifest.ts
+++ b/src/main/providers/manifest.ts
@@ -34,6 +34,22 @@ export type AcpLaunch =
   | { via: 'binary'; command: string; args: readonly string[] }
   | { via: 'adapter'; package: string; bin: string };
 
+/**
+ * A model in a provider's curated catalog. The metadata fields are the
+ * vendor's documented facts for the exact endpoint we ship; anything declared
+ * here overrides the litellm catalog's bare-name, cross-provider guess (see
+ * agent/models/lookup.ts). Declare only what the vendor states — undeclared
+ * fields still resolve through litellm.
+ */
+export type ManifestModel = {
+  id: string;
+  contextTokens?: number;
+  outputTokens?: number;
+  vision?: boolean;
+  toolCall?: boolean;
+  reasoning?: boolean;
+};
+
 export type CloudApiManifest = {
   id: string;
   kind: 'cloud-api';
@@ -45,7 +61,7 @@ export type CloudApiManifest = {
   /** Where the user goes to generate their API key. */
   consoleUrl: string;
   /** Models Atrium knows about for this provider; user toggles a subset on. */
-  models: readonly string[];
+  models: readonly ManifestModel[];
 };
 
 export type LocalCliManifest = {
@@ -76,6 +92,28 @@ export type LocalServiceManifest = {
 
 export type ProviderManifest = CloudApiManifest | LocalCliManifest | LocalServiceManifest;
 
+/**
+ * Ark plan models missing from the litellm dataset — without declared windows
+ * the context gauge and compaction threshold would fall back to 128k, half the
+ * documented size. Doc: 256k context / 128k output, vision, thinking-capable.
+ */
+const DOUBAO_SEED_2_META = {
+  contextTokens: 262_144,
+  outputTokens: 131_072,
+  vision: true,
+  toolCall: true,
+  reasoning: true,
+} as const;
+
+// Auto-dispatch alias; sized to the smallest window in its dispatch pool.
+const ARK_CODE_LATEST: ManifestModel = {
+  id: 'ark-code-latest',
+  contextTokens: 200_000,
+  outputTokens: 131_072,
+  toolCall: true,
+  reasoning: true,
+};
+
 export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
   // ── Cloud API ────────────────────────────────────────────────────────────
   {
@@ -86,7 +124,7 @@ export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
     protocol: 'anthropic',
     defaultBaseUrl: 'https://api.anthropic.com',
     consoleUrl: 'https://console.anthropic.com/settings/keys',
-    models: ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5'],
+    models: [{ id: 'claude-opus-4-7' }, { id: 'claude-sonnet-4-6' }, { id: 'claude-haiku-4-5' }],
   },
   {
     id: 'openai',
@@ -96,7 +134,7 @@ export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
     protocol: 'openai-compatible',
     defaultBaseUrl: 'https://api.openai.com/v1',
     consoleUrl: 'https://platform.openai.com/api-keys',
-    models: ['gpt-5', 'gpt-4.1', 'o4-mini'],
+    models: [{ id: 'gpt-5' }, { id: 'gpt-4.1' }, { id: 'o4-mini' }],
   },
   {
     id: 'deepseek',
@@ -106,7 +144,7 @@ export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
     protocol: 'openai-compatible',
     defaultBaseUrl: 'https://api.deepseek.com',
     consoleUrl: 'https://platform.deepseek.com/api_keys',
-    models: ['deepseek-chat', 'deepseek-reasoner'],
+    models: [{ id: 'deepseek-chat' }, { id: 'deepseek-reasoner' }],
   },
   {
     id: 'google',
@@ -116,7 +154,7 @@ export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
     protocol: 'google-gemini',
     defaultBaseUrl: 'https://generativelanguage.googleapis.com/v1beta',
     consoleUrl: 'https://aistudio.google.com/apikey',
-    models: ['gemini-2.5-pro', 'gemini-2.5-flash'],
+    models: [{ id: 'gemini-2.5-pro' }, { id: 'gemini-2.5-flash' }],
   },
   {
     id: 'moonshot',
@@ -126,7 +164,7 @@ export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
     protocol: 'openai-compatible',
     defaultBaseUrl: 'https://api.moonshot.cn/v1',
     consoleUrl: 'https://platform.moonshot.cn/console/api-keys',
-    models: ['moonshot-v1-128k', 'moonshot-v1-32k'],
+    models: [{ id: 'moonshot-v1-128k' }, { id: 'moonshot-v1-32k' }],
   },
   {
     id: 'kimi-coding',
@@ -136,7 +174,7 @@ export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
     protocol: 'anthropic',
     defaultBaseUrl: 'https://api.moonshot.cn/anthropic',
     consoleUrl: 'https://platform.moonshot.cn/',
-    models: ['kimi-k2'],
+    models: [{ id: 'kimi-k2' }],
   },
   {
     id: 'zai-coding',
@@ -146,7 +184,7 @@ export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
     protocol: 'anthropic',
     defaultBaseUrl: 'https://open.bigmodel.cn/api/anthropic',
     consoleUrl: 'https://open.bigmodel.cn/',
-    models: ['glm-4.6'],
+    models: [{ id: 'glm-4.6' }],
   },
   {
     id: 'volcengine-agent',
@@ -160,18 +198,18 @@ export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
     // The plan endpoint has no model-listing API; this is the doc's supported
     // text-generation set (each id verified against the live endpoint).
     models: [
-      'ark-code-latest',
-      'doubao-seed-2.0-mini',
-      'doubao-seed-2.0-lite',
-      'doubao-seed-2.0-code',
-      'doubao-seed-2.0-pro',
-      'deepseek-v4-flash',
-      'deepseek-v4-pro',
-      'minimax-m2.7',
-      'minimax-m3',
-      'glm-5.2',
-      'kimi-k2.6',
-      'kimi-k2.7-code',
+      ARK_CODE_LATEST,
+      { id: 'doubao-seed-2.0-mini', ...DOUBAO_SEED_2_META },
+      { id: 'doubao-seed-2.0-lite', ...DOUBAO_SEED_2_META },
+      { id: 'doubao-seed-2.0-code', ...DOUBAO_SEED_2_META },
+      { id: 'doubao-seed-2.0-pro', ...DOUBAO_SEED_2_META },
+      { id: 'deepseek-v4-flash' },
+      { id: 'deepseek-v4-pro' },
+      { id: 'minimax-m2.7' },
+      { id: 'minimax-m3' },
+      { id: 'glm-5.2' },
+      { id: 'kimi-k2.6' },
+      { id: 'kimi-k2.7-code' },
     ],
   },
   {
@@ -185,18 +223,24 @@ export const PROVIDER_MANIFEST: readonly ProviderManifest[] = [
       'https://console.volcengine.com/ark/region:ark+cn-beijing/openManagement?LLM=%7B%7D&advancedActiveKey=subscribe',
     // Like the agent plan: no model-listing API, doc's text-generation set.
     models: [
-      'ark-code-latest',
-      'doubao-seed-code',
-      'doubao-seed-2.0-code',
-      'doubao-seed-2.0-lite',
-      'doubao-seed-2.0-pro',
-      'deepseek-v4-flash',
-      'deepseek-v4-pro',
-      'minimax-m2.7',
-      'minimax-m3',
-      'glm-5.2',
-      'kimi-k2.6',
-      'kimi-k2.7-code',
+      ARK_CODE_LATEST,
+      {
+        id: 'doubao-seed-code',
+        contextTokens: 262_144,
+        vision: true,
+        toolCall: true,
+        reasoning: true,
+      },
+      { id: 'doubao-seed-2.0-code', ...DOUBAO_SEED_2_META },
+      { id: 'doubao-seed-2.0-lite', ...DOUBAO_SEED_2_META },
+      { id: 'doubao-seed-2.0-pro', ...DOUBAO_SEED_2_META },
+      { id: 'deepseek-v4-flash' },
+      { id: 'deepseek-v4-pro' },
+      { id: 'minimax-m2.7' },
+      { id: 'minimax-m3' },
+      { id: 'glm-5.2' },
+      { id: 'kimi-k2.6' },
+      { id: 'kimi-k2.7-code' },
     ],
   },
   {

--- a/src/renderer/src/components/settings/providers/ProviderDetail.tsx
+++ b/src/renderer/src/components/settings/providers/ProviderDetail.tsx
@@ -75,7 +75,9 @@ function CloudApiForm({
   };
   // Manifest models are the curated floor — some providers (coding/agent
   // plans) expose no listing endpoint, so fetch results only extend them.
-  const models = [...new Set([...provider.models, ...(config.fetchedModels ?? [])])];
+  const models = [
+    ...new Set([...provider.models.map((m) => m.id), ...(config.fetchedModels ?? [])]),
+  ];
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-5">
       <ApiKeyField


### PR DESCRIPTION
## Problem

One short message into an `ark-code-latest` thread, the context gauge already read ~29%. The turn's token **usage is correct** (Atrium's system prompt + tool definitions genuinely weigh ~35–48k tokens; same scale on gpt-5.5 / deepseek threads) — the **denominator was wrong**: the Ark plans' model ids don't resolve in litellm's dataset, so `maxContextTokens` fell back to 128k, half the documented window. The same wrong window also drives the auto-compaction threshold, so compaction would fire twice as early as needed.

## Design

The provider manifest's model entries now carry the join, not copies of the data:

```ts
// litellm keys the family version-pinned — alias the serving id to the exact key
{ id: 'doubao-seed-2.0-code', catalogId: 'volcengine/doubao-seed-2-0-code-preview-260215' }

// ids litellm doesn't carry at all get vendor-documented fields
{ id: 'ark-code-latest', contextTokens: 200_000, outputTokens: 131_072, toolCall: true, reasoning: true }
```

- **`catalogId`** maps a vendor serving id to its litellm key when the spellings differ (dots vs dashes + date suffix). Window, capability bits, and pricing then flow from the litellm catalog — nothing hand-copied, upstream updates arrive with the normal catalog refresh. Verified against the bundled snapshot: all four `doubao-seed-2.0-*` ids resolve (256k window, vision/tool/reasoning bits).
- **Explicit fields** remain only for ids litellm cannot know: `ark-code-latest` (Ark's auto-dispatch alias — 200k, the smallest window in its dispatch pool) and the retired `doubao-seed-code`. Declared fields override the litellm entry (vendor doc beats bare-name cross-vendor guess); undeclared fields still resolve through it.
- Resolution order: exact litellm key → manifest `catalogId` alias → bare-name scan → declared-fields overlay → 128k fallback. A vanished alias key degrades to the conservative fallback rather than breaking.

## Tested

Unit tests: alias resolution (incl. vendor-prefix/casing on the serving id), alias-key-vanished degradation, manual-overlay coverage, field-level override-and-merge. 509 pass, typecheck + biome clean. End-to-end check against the real bundled snapshot confirms all six Ark ids resolve with correct windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)