### PR TITLE
feat(agent): detect and break repetitive tool-call loops

### DIFF
--- a/src/main/agent/middleware/builtins/loop-detection.test.ts
+++ b/src/main/agent/middleware/builtins/loop-detection.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from 'bun:test';
+import type { ModelMessage } from 'ai';
+import type { RunContext } from '../types';
+import { loopDetectionMiddleware } from './loop-detection';
+
+const call = (id: string, name: string, input: unknown): ModelMessage => ({
+  role: 'assistant',
+  content: [{ type: 'tool-call', toolCallId: id, toolName: name, input }],
+});
+
+const textOf = (m: ModelMessage | undefined): string =>
+  typeof m?.content === 'string' ? m.content : '';
+
+const freshCtx = (): RunContext => ({ scratch: new Map() }) as unknown as RunContext;
+
+const history: ModelMessage[] = [{ role: 'user', content: 'fill the form' }];
+
+/** Drive beforeStep like streamText: step 0 sees only history, each later step
+ *  sees history plus every call made so far. */
+async function stepThrough(ctx: RunContext, mw = loopDetectionMiddleware(), calls: ModelMessage[]) {
+  const mws = calls.map((_, i) => [...history, ...calls.slice(0, i + 1)]);
+  await mw.beforeStep?.(ctx, { stepNumber: 0, messages: history });
+  let last: Awaited<ReturnType<NonNullable<typeof mw.beforeStep>>> = undefined;
+  for (const [i, messages] of mws.entries()) {
+    last = await mw.beforeStep?.(ctx, { stepNumber: i + 1, messages });
+  }
+  return last;
+}
+
+test('warns once when the same call repeats warnAt times', async () => {
+  const mw = loopDetectionMiddleware();
+  const ctx = freshCtx();
+  const repeat = (i: number) => call(`c${i}`, 'browser_type', { text: 'hi' });
+
+  await mw.beforeStep?.(ctx, { stepNumber: 0, messages: history });
+  expect(
+    await mw.beforeStep?.(ctx, { stepNumber: 1, messages: [...history, repeat(1)] }),
+  ).toBeUndefined();
+  expect(
+    await mw.beforeStep?.(ctx, { stepNumber: 2, messages: [...history, repeat(1), repeat(2)] }),
+  ).toBeUndefined();
+
+  const o = await mw.beforeStep?.(ctx, {
+    stepNumber: 3,
+    messages: [...history, repeat(1), repeat(2), repeat(3)],
+  });
+  expect(textOf(o?.messages?.at(-1))).toContain('3 times');
+  expect(o?.toolChoice).toBeUndefined();
+
+  // Fourth repeat: already warned for this key, nothing new until the hard stop.
+  expect(
+    await mw.beforeStep?.(ctx, {
+      stepNumber: 4,
+      messages: [...history, repeat(1), repeat(2), repeat(3), repeat(4)],
+    }),
+  ).toBeUndefined();
+});
+
+test('cuts off tool use at stopAt and keeps it off for later steps', async () => {
+  const ctx = freshCtx();
+  const calls = [1, 2, 3, 4, 5].map((i) => call(`c${i}`, 'browser_type', { text: 'hi' }));
+  const mw = loopDetectionMiddleware();
+  const o = await stepThrough(ctx, mw, calls);
+  expect(o?.toolChoice).toBe('none');
+  expect(textOf(o?.messages?.at(-1))).toContain('disabled');
+
+  // No new calls, but the stop must hold until the turn ends.
+  const later = await mw.beforeStep?.(ctx, { stepNumber: 7, messages: [...history, ...calls] });
+  expect(later?.toolChoice).toBe('none');
+});
+
+test('different arguments never accumulate into one loop', async () => {
+  const calls = [1, 2, 3, 4, 5].map((i) => call(`c${i}`, 'bash', { command: `ls ${i}` }));
+  expect(await stepThrough(freshCtx(), undefined, calls)).toBeUndefined();
+});
+
+test('argument key order does not split the identical-call key', async () => {
+  const calls = [
+    call('c1', 'edit', { a: 1, b: 2 }),
+    call('c2', 'edit', { b: 2, a: 1 }),
+    call('c3', 'edit', { a: 1, b: 2 }),
+  ];
+  const o = await stepThrough(freshCtx(), undefined, calls);
+  expect(textOf(o?.messages?.at(-1))).toContain('3 times');
+});
+
+test('pre-run history is seeded, not counted', async () => {
+  const mw = loopDetectionMiddleware();
+  const ctx = freshCtx();
+  const old = [1, 2, 3].map((i) => call(`h${i}`, 'bash', { command: 'ls' }));
+  await mw.beforeStep?.(ctx, { stepNumber: 0, messages: [...history, ...old] });
+
+  // Two fresh identical calls on top of three historical ones: still under warnAt.
+  const fresh = [call('c1', 'bash', { command: 'ls' }), call('c2', 'bash', { command: 'ls' })];
+  const o = await mw.beforeStep?.(ctx, {
+    stepNumber: 1,
+    messages: [...history, ...old, ...fresh],
+  });
+  expect(o).toBeUndefined();
+});
+
+test('ignores plain-text assistant messages', async () => {
+  const mw = loopDetectionMiddleware();
+  const ctx = freshCtx();
+  const messages: ModelMessage[] = [...history, { role: 'assistant', content: 'thinking…' }];
+  await mw.beforeStep?.(ctx, { stepNumber: 0, messages });
+  expect(await mw.beforeStep?.(ctx, { stepNumber: 1, messages })).toBeUndefined();
+});

--- a/src/main/agent/middleware/builtins/loop-detection.ts
+++ b/src/main/agent/middleware/builtins/loop-detection.ts
@@ -1,0 +1,124 @@
+import type { ModelMessage, ToolCallPart } from 'ai';
+import { createLogger } from '../../../log';
+import type { AgentMiddleware, RunContext, StepInfo, StepOverride } from '../types';
+
+const log = createLogger('loop-detection');
+
+const DEFAULT_WARN_AT = 3;
+const DEFAULT_STOP_AT = 5;
+
+const SCRATCH_KEY = 'loop-detection:state';
+
+type LoopState = {
+  /** toolCallIds already tallied, seeded with pre-run history so it isn't counted. */
+  counted: Set<string>;
+  /** Identical-call key → times the model made that exact call this run. */
+  counts: Map<string, number>;
+  /** Keys already warned about — one warning each, then only the hard stop is left. */
+  warned: Set<string>;
+  /** Set when the hard limit trips; every remaining step stays text-only. */
+  stopNotice: string | null;
+};
+
+export type LoopDetectionOptions = {
+  /** Identical calls before a warning is injected, default 3. */
+  warnAt?: number;
+  /** Identical calls before tool use is cut off for the turn, default 5. */
+  stopAt?: number;
+};
+
+const warnNotice = (name: string, count: number): string =>
+  `<system-reminder>You have made the exact same ${name} call (identical arguments) ${count} times this turn. Repeating it will not change the outcome. Re-read the tool's last output carefully and change your approach: different arguments, a different tool, or ask the user how to proceed.</system-reminder>`;
+
+const stopNotice = (name: string, count: number): string =>
+  `<system-reminder>Loop detected: the exact same ${name} call was repeated ${count} times without progress, so tool use is disabled for the rest of this turn. Summarize what you were trying to do, what kept failing, and what you need to continue.</system-reminder>`;
+
+/** JSON.stringify with recursively sorted object keys, so two inputs that differ
+ *  only in property order produce the same identical-call key. */
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'undefined';
+}
+
+function toolCallsOf(messages: ModelMessage[]): ToolCallPart[] {
+  const calls: ToolCallPart[] = [];
+  for (const m of messages) {
+    if (m.role !== 'assistant' || typeof m.content === 'string') continue;
+    for (const part of m.content) {
+      if (part.type === 'tool-call') calls.push(part);
+    }
+  }
+  return calls;
+}
+
+/**
+ * Breaks repetitive tool-call loops. A model that keeps making the exact same
+ * call (same tool, same arguments) is stuck — typically a weak model re-issuing
+ * a hallucinated tool name after every error — and without intervention the
+ * only brake is the run's step cap. Detection scans the step's assistant
+ * tool-call parts rather than hooking beforeToolUse, because a call to a
+ * nonexistent tool fails name resolution before execution and would never
+ * reach the tool hooks. At `warnAt` repeats a one-off reminder is appended
+ * after the tool results; at `stopAt` tool choice is forced to 'none' for the
+ * rest of the turn so the model must wrap up in text. Both injections are
+ * per-step message overrides — transient by design, never persisted.
+ */
+export function loopDetectionMiddleware(options: LoopDetectionOptions = {}): AgentMiddleware {
+  const warnAt = options.warnAt ?? DEFAULT_WARN_AT;
+  const stopAt = options.stopAt ?? DEFAULT_STOP_AT;
+
+  return {
+    name: 'loop-detection',
+    beforeStep(ctx: RunContext, { messages }: StepInfo): StepOverride | undefined {
+      const state = ctx.scratch.get(SCRATCH_KEY) as LoopState | undefined;
+      if (!state) {
+        // First step: everything in view predates this run. Seed it uncounted
+        // so a call the user legitimately re-asked for across turns starts at
+        // zero instead of inheriting its history.
+        ctx.scratch.set(SCRATCH_KEY, {
+          counted: new Set(toolCallsOf(messages).map((c) => c.toolCallId)),
+          counts: new Map(),
+          warned: new Set(),
+          stopNotice: null,
+        } satisfies LoopState);
+        return undefined;
+      }
+
+      const warnings: string[] = [];
+      for (const call of toolCallsOf(messages)) {
+        if (state.counted.has(call.toolCallId)) continue;
+        state.counted.add(call.toolCallId);
+        const key = `${call.toolName}:${stableStringify(call.input)}`;
+        const n = (state.counts.get(key) ?? 0) + 1;
+        state.counts.set(key, n);
+        if (n >= stopAt) {
+          if (!state.stopNotice) {
+            state.stopNotice = stopNotice(call.toolName, n);
+            log.warn(`hard stop: ${call.toolName} repeated ${n}x with identical input`);
+          }
+        } else if (n >= warnAt && !state.warned.has(key)) {
+          state.warned.add(key);
+          warnings.push(warnNotice(call.toolName, n));
+          log.info(`warning injected: ${call.toolName} repeated ${n}x with identical input`);
+        }
+      }
+
+      if (state.stopNotice) {
+        return {
+          messages: [...messages, { role: 'user', content: state.stopNotice }],
+          toolChoice: 'none',
+        };
+      }
+      if (warnings.length > 0) {
+        return { messages: [...messages, { role: 'user', content: warnings.join('\n\n') }] };
+      }
+      return undefined;
+    },
+  };
+}

--- a/src/main/agent/middleware/index.ts
+++ b/src/main/agent/middleware/index.ts
@@ -6,6 +6,7 @@ export {
 } from './builtins/compaction';
 export { dateMiddleware } from './builtins/date';
 export { type InstructionsOptions, instructionsMiddleware } from './builtins/instructions';
+export { type LoopDetectionOptions, loopDetectionMiddleware } from './builtins/loop-detection';
 export { type MemoryOptions, memoryMiddleware } from './builtins/memory';
 export { metadataMiddleware } from './builtins/metadata';
 export { type PersistFn, persistenceMiddleware } from './builtins/persistence';

--- a/src/main/agent/middleware/runner.test.ts
+++ b/src/main/agent/middleware/runner.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'bun:test';
+import type { ModelMessage } from 'ai';
 import {
   composeAfterStep,
   composeBeforeStep,
@@ -43,6 +44,20 @@ test('composeBeforeStep merges overrides in order (later wins on conflict)', asy
   ];
   const merged = await composeBeforeStep(ctx, mws)({ stepNumber: 0, messages: [] });
   expect(merged).toEqual({ system: 'c', activeTools: ['bash'] });
+});
+
+test('composeBeforeStep pipelines a messages override into later middlewares', async () => {
+  const folded: ModelMessage[] = [{ role: 'user', content: 'summary' }];
+  const warning: ModelMessage = { role: 'user', content: 'warn' };
+  const mws: AgentMiddleware[] = [
+    { name: 'fold', beforeStep: () => ({ messages: folded }) },
+    { name: 'append', beforeStep: (_c, step) => ({ messages: [...step.messages, warning] }) },
+  ];
+  const merged = await composeBeforeStep(
+    ctx,
+    mws,
+  )({ stepNumber: 0, messages: [{ role: 'user', content: 'original' }] });
+  expect(merged.messages).toEqual([...folded, warning]);
 });
 
 test('composeAfterStep awaits every middleware in order', async () => {

--- a/src/main/agent/middleware/runner.ts
+++ b/src/main/agent/middleware/runner.ts
@@ -34,7 +34,10 @@ export function composeBeforeStep(ctx: RunContext, mws: AgentMiddleware[]) {
   return async (step: StepInfo): Promise<StepOverride> => {
     const merged: StepOverride = {};
     for (const m of mws) {
-      const o = await m.beforeStep?.(ctx, step);
+      // Each middleware sees the merged-so-far message view, so an appender
+      // composes with an upstream rewrite instead of clobbering it. Scalar
+      // fields stay last-wins.
+      const o = await m.beforeStep?.(ctx, { ...step, messages: merged.messages ?? step.messages });
       if (o) Object.assign(merged, o);
     }
     return merged;

--- a/src/main/agent/middleware/types.ts
+++ b/src/main/agent/middleware/types.ts
@@ -4,6 +4,7 @@ import type {
   ModelMessage,
   TextStreamPart,
   Tool,
+  ToolChoice,
   ToolSet,
   UIMessage,
   UIMessageStreamWriter,
@@ -46,6 +47,7 @@ export type StepOverride = {
   system?: string;
   messages?: ModelMessage[];
   activeTools?: ToolName[];
+  toolChoice?: ToolChoice<ToolSet>;
 };
 
 export type StepResultInfo = {

--- a/src/main/agent/subagent/run.ts
+++ b/src/main/agent/subagent/run.ts
@@ -2,7 +2,12 @@ import type { ToolName } from '@shared/tools';
 import { convertToModelMessages, generateId, stepCountIs, streamText, type UIMessage } from 'ai';
 import { recordUsage, tokenCountsOf } from '../../db/usage';
 import { createLogger } from '../../log';
-import { compactionMiddleware, composeBeforeStep, type RunContext } from '../middleware';
+import {
+  compactionMiddleware,
+  composeBeforeStep,
+  loopDetectionMiddleware,
+  type RunContext,
+} from '../middleware';
 import { injectSystemReminder } from '../middleware/shared/reminder';
 import type { ModelPricing } from '../models/types';
 import { currentDateNote, workspaceGuidance } from '../prompts';
@@ -96,6 +101,7 @@ export async function runSubagent(opts: RunSubagentOptions): Promise<SubagentRes
       persist: () => {},
       preservers: [todoPreserver],
     }),
+    loopDetectionMiddleware(),
   ];
   const beforeStep = composeBeforeStep(subCtx, middlewares);
 

--- a/src/main/server/http.ts
+++ b/src/main/server/http.ts
@@ -13,6 +13,7 @@ import {
   compactThread,
   dateMiddleware,
   instructionsMiddleware,
+  loopDetectionMiddleware,
   memoryMiddleware,
   metadataMiddleware,
   persistenceMiddleware,
@@ -259,6 +260,10 @@ export function startHttpServer(deps: {
           persist: persistMessage,
           preservers: [todoPreserver, skillPreserver],
         }),
+        // After compaction: both override the step's messages, and the runner
+        // pipelines them in list order, so the loop reminder lands on the
+        // folded view instead of being clobbered by it.
+        loopDetectionMiddleware(),
         skillsMiddleware({ skills }),
         // Run skills → memory → instructions so the injected blocks end up ordered
         // custom-instructions → memory → skills after each prepend.


### PR DESCRIPTION
## What

A model that keeps making the exact same tool call (same name, same arguments) is stuck — the incident: doubao-seed-2.0-code hallucinated `mcp__browser-login__browser-type` (hyphen) for the registered `browser_type`, got the NoSuchTool error fed back each step, and re-issued the identical call until the 100-step cap.

Two commits:

1. **refactor(agent): pipeline beforeStep message overrides through middlewares** — `composeBeforeStep` was last-wins on the `messages` field, so two middlewares overriding messages (compaction + this one) would clobber each other. Each middleware now sees the merged-so-far view; scalar fields stay last-wins.
2. **feat(agent): detect and break repetitive tool-call loops** — new `loopDetectionMiddleware`:
   - Counts identical calls (tool name + key-order-insensitive argument hash) per run, in `beforeStep` from the step's message view — that path also sees calls to **nonexistent** tools, which never reach `beforeToolUse`.
   - Pre-run history is seeded uncounted, so a user legitimately re-asking across turns starts at zero.
   - **3 identical calls** → one-off `<system-reminder>` appended after the tool results telling the model to change approach.
   - **5 identical calls** → `toolChoice: 'none'` for the rest of the turn (kept on every remaining step) + a stop notice, forcing a text wrap-up.
   - Injections are per-step model-view overrides — transient, never persisted to the thread.
   - Registered in the main agent loop (after compaction, riding its folded view) and in subagents.

Thresholds match the deer-flow / code-artisan implementations (warn 3 / stop 5). Scope per review: no tool-name auto-repair, no per-tool frequency layer.

## Test plan

- `bun test src/main` — 464 pass, including new `loop-detection.test.ts` (warn once, hard stop persists, different args don't accumulate, key-order-insensitive hashing, history seeding) and a new `composeBeforeStep` pipeline test.
- `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)