### PR TITLE
feat(agent): add retry backoff and anthropic prompt caching for plan providers

### DIFF
--- a/src/main/agent/errors.ts
+++ b/src/main/agent/errors.ts
@@ -1,6 +1,18 @@
 import { APICallError, RetryError } from 'ai';
 
 /**
+ * Retries for agent-loop model calls. The SDK default (2, exponential backoff
+ * from 2s) gives up within ~6 seconds — too brief to outlive the per-minute
+ * TPM throttles subscription providers enforce, where a 429 clears only once
+ * the minute window slides. Six attempts back off through ~2 minutes
+ * (2s→64s, or the server's Retry-After when present), long enough to ride out
+ * a throttle window unattended. Genuinely non-retryable errors (auth,
+ * validation) still surface immediately — the SDK only retries errors it
+ * marks retryable.
+ */
+export const MODEL_CALL_MAX_RETRIES = 6;
+
+/**
  * A human-readable message for the client. createUIMessageStream masks errors
  * as a generic string by default (don't leak internals); we override that to
  * surface the real reason. Provider errors bury the useful text in the response

--- a/src/main/agent/errors.ts
+++ b/src/main/agent/errors.ts
@@ -4,13 +4,14 @@ import { APICallError, RetryError } from 'ai';
  * Retries for agent-loop model calls. The SDK default (2, exponential backoff
  * from 2s) gives up within ~6 seconds — too brief to outlive the per-minute
  * TPM throttles subscription providers enforce, where a 429 clears only once
- * the minute window slides. Six attempts back off through ~2 minutes
- * (2s→64s, or the server's Retry-After when present), long enough to ride out
- * a throttle window unattended. Genuinely non-retryable errors (auth,
- * validation) still surface immediately — the SDK only retries errors it
- * marks retryable.
+ * the minute window slides. Ten attempts back off exponentially from 2s
+ * (deferring to the server's Retry-After when present), which is enough
+ * patience for even stubborn multi-minute throttles; a waiting retry is
+ * still cancelled instantly by the turn's abort signal, and genuinely
+ * non-retryable errors (auth, validation) surface immediately — the SDK
+ * only retries errors it marks retryable.
  */
-export const MODEL_CALL_MAX_RETRIES = 6;
+export const MODEL_CALL_MAX_RETRIES = 10;
 
 /**
  * A human-readable message for the client. createUIMessageStream masks errors

--- a/src/main/agent/prompt-cache.test.ts
+++ b/src/main/agent/prompt-cache.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from 'bun:test';
+import type { ModelMessage } from 'ai';
+import { stampCacheBreakpoints, usesAnthropicPromptCache } from './prompt-cache';
+
+const ephemeral = { anthropic: { cacheControl: { type: 'ephemeral' } } };
+
+test('stamps the last two messages and leaves the rest untouched', () => {
+  const messages: ModelMessage[] = [
+    { role: 'user', content: 'one' },
+    { role: 'assistant', content: 'two' },
+    { role: 'user', content: 'three' },
+  ];
+  const stamped = stampCacheBreakpoints(messages);
+  expect(stamped[0].providerOptions).toBeUndefined();
+  expect(stamped[1].providerOptions).toEqual(ephemeral);
+  expect(stamped[2].providerOptions).toEqual(ephemeral);
+});
+
+test('handles arrays shorter than the breakpoint count', () => {
+  const stamped = stampCacheBreakpoints([{ role: 'user', content: 'only' }]);
+  expect(stamped).toHaveLength(1);
+  expect(stamped[0].providerOptions).toEqual(ephemeral);
+  expect(stampCacheBreakpoints([])).toEqual([]);
+});
+
+test('copies stamped messages instead of mutating the originals', () => {
+  const original: ModelMessage = { role: 'user', content: 'tail' };
+  const stamped = stampCacheBreakpoints([original]);
+  expect(original.providerOptions).toBeUndefined();
+  expect(stamped[0]).not.toBe(original);
+});
+
+test('merges with existing providerOptions rather than replacing them', () => {
+  const messages: ModelMessage[] = [
+    {
+      role: 'user',
+      content: 'tail',
+      providerOptions: { anthropic: { sendReasoning: true }, openai: { store: false } },
+    },
+  ];
+  const stamped = stampCacheBreakpoints(messages);
+  expect(stamped[0].providerOptions).toEqual({
+    anthropic: { sendReasoning: true, cacheControl: { type: 'ephemeral' } },
+    openai: { store: false },
+  });
+});
+
+test('usesAnthropicPromptCache is true only for anthropic-protocol cloud providers', () => {
+  expect(usesAnthropicPromptCache('anthropic')).toBe(true);
+  expect(usesAnthropicPromptCache('volcengine-agent')).toBe(true);
+  expect(usesAnthropicPromptCache('openai')).toBe(false);
+  expect(usesAnthropicPromptCache('ollama')).toBe(false);
+  expect(usesAnthropicPromptCache('nonexistent')).toBe(false);
+  expect(usesAnthropicPromptCache(undefined)).toBe(false);
+});

--- a/src/main/agent/prompt-cache.ts
+++ b/src/main/agent/prompt-cache.ts
@@ -1,0 +1,42 @@
+import type { ModelMessage } from 'ai';
+import { getProviderManifest } from '../providers/manifest';
+
+/**
+ * Whether prompt caching for this provider needs explicit markers. On the
+ * Anthropic protocol nothing is cached unless a message carries a
+ * cache_control breakpoint — omit them and every step re-bills the full,
+ * growing history as fresh input. (OpenAI-compatible and Gemini endpoints
+ * cache prefixes implicitly, so they need no markers.)
+ */
+export function usesAnthropicPromptCache(providerId?: string): boolean {
+  const manifest = providerId ? getProviderManifest(providerId) : undefined;
+  return manifest?.kind === 'cloud-api' && manifest.protocol === 'anthropic';
+}
+
+/**
+ * Stamp ephemeral cache breakpoints on the last two messages — Anthropic's
+ * documented incremental-caching pattern for conversations. A breakpoint on
+ * the tail caches the entire prefix (tools + system + history) as one entry,
+ * and the next step's longer prompt reuses it as its longest cached prefix;
+ * the second breakpoint keeps the previous position addressable across a
+ * retried or branched step. Messages are copied, not mutated: the loop's own
+ * message array never carries stamps, so breakpoints can't accumulate on old
+ * positions past Anthropic's four-marker limit as the tail moves.
+ */
+export function stampCacheBreakpoints(messages: ModelMessage[]): ModelMessage[] {
+  const stampFrom = Math.max(0, messages.length - 2);
+  return messages.map((message, i) =>
+    i < stampFrom
+      ? message
+      : {
+          ...message,
+          providerOptions: {
+            ...message.providerOptions,
+            anthropic: {
+              ...message.providerOptions?.anthropic,
+              cacheControl: { type: 'ephemeral' },
+            },
+          },
+        },
+  );
+}

--- a/src/main/agent/run.ts
+++ b/src/main/agent/run.ts
@@ -22,6 +22,7 @@ import {
   runBeforeRun,
 } from './middleware';
 import { readSoul } from './profile/paths';
+import { stampCacheBreakpoints, usesAnthropicPromptCache } from './prompt-cache';
 import { buildSystemPrompt } from './prompts';
 import type { Sandbox } from './sandbox/types';
 
@@ -95,6 +96,7 @@ export async function runAgent(opts: RunAgentOptions): Promise<ReadableStream<UI
       await runBeforeRun(ctx, opts.middlewares);
 
       const beforeStep = composeBeforeStep(ctx, opts.middlewares);
+      const stampCache = usesAnthropicPromptCache(opts.providerId);
       const result = streamText({
         model: opts.model,
         system: ctx.request.system,
@@ -109,7 +111,14 @@ export async function runAgent(opts: RunAgentOptions): Promise<ReadableStream<UI
         // compaction (beforeStep) keeps the loop from overflowing the window.
         stopWhen: stepCountIs(100),
         maxRetries: MODEL_CALL_MAX_RETRIES,
-        prepareStep: ({ stepNumber, messages }) => beforeStep({ stepNumber, messages }),
+        // Cache stamping happens after the middleware chain, not inside it:
+        // breakpoints are wire metadata that must land on the final per-step
+        // message view, whatever compaction or other overrides produced.
+        prepareStep: async ({ stepNumber, messages }) => {
+          const override = await beforeStep({ stepNumber, messages });
+          if (!stampCache) return override;
+          return { ...override, messages: stampCacheBreakpoints(override.messages ?? messages) };
+        },
         abortSignal: opts.abortSignal,
         experimental_transform: smoothStream({ chunking: 'word', delayInMs: 12 }),
         // Hands the run's RunContext to tool execute (the task tool reads it to

--- a/src/main/agent/run.ts
+++ b/src/main/agent/run.ts
@@ -12,7 +12,7 @@ import {
   type UIMessageChunk,
 } from 'ai';
 import type { Db } from '../db';
-import { readableError } from './errors';
+import { MODEL_CALL_MAX_RETRIES, readableError } from './errors';
 import {
   type AgentMiddleware,
   composeBeforeStep,
@@ -108,6 +108,7 @@ export async function runAgent(opts: RunAgentOptions): Promise<ReadableStream<UI
         // Complex coding tasks routinely exceed a dozen steps; within-turn
         // compaction (beforeStep) keeps the loop from overflowing the window.
         stopWhen: stepCountIs(100),
+        maxRetries: MODEL_CALL_MAX_RETRIES,
         prepareStep: ({ stepNumber, messages }) => beforeStep({ stepNumber, messages }),
         abortSignal: opts.abortSignal,
         experimental_transform: smoothStream({ chunking: 'word', delayInMs: 12 }),

--- a/src/main/agent/subagent/run.ts
+++ b/src/main/agent/subagent/run.ts
@@ -2,6 +2,7 @@ import type { ToolName } from '@shared/tools';
 import { convertToModelMessages, generateId, stepCountIs, streamText, type UIMessage } from 'ai';
 import { recordUsage, tokenCountsOf } from '../../db/usage';
 import { createLogger } from '../../log';
+import { MODEL_CALL_MAX_RETRIES } from '../errors';
 import {
   compactionMiddleware,
   composeBeforeStep,
@@ -115,6 +116,7 @@ export async function runSubagent(opts: RunSubagentOptions): Promise<SubagentRes
     messages: await convertToModelMessages(messages, { tools }),
     tools,
     stopWhen: stepCountIs(SUBAGENT_MAX_STEPS),
+    maxRetries: MODEL_CALL_MAX_RETRIES,
     prepareStep: ({ stepNumber, messages }) => beforeStep({ stepNumber, messages }),
     abortSignal: opts.abortSignal,
     // Bubble each step's completed tool calls up to the parent so its task card

--- a/src/main/agent/subagent/run.ts
+++ b/src/main/agent/subagent/run.ts
@@ -11,6 +11,7 @@ import {
 } from '../middleware';
 import { injectSystemReminder } from '../middleware/shared/reminder';
 import type { ModelPricing } from '../models/types';
+import { stampCacheBreakpoints, usesAnthropicPromptCache } from '../prompt-cache';
 import { currentDateNote, workspaceGuidance } from '../prompts';
 import { todoPreserver } from '../tools/builtins/todo';
 import { filterToolsForSubagent, type SubagentDef } from './defs';
@@ -117,7 +118,12 @@ export async function runSubagent(opts: RunSubagentOptions): Promise<SubagentRes
     tools,
     stopWhen: stepCountIs(SUBAGENT_MAX_STEPS),
     maxRetries: MODEL_CALL_MAX_RETRIES,
-    prepareStep: ({ stepNumber, messages }) => beforeStep({ stepNumber, messages }),
+    // Same post-middleware cache stamping as the parent loop (see agent/run.ts).
+    prepareStep: async ({ stepNumber, messages }) => {
+      const override = await beforeStep({ stepNumber, messages });
+      if (!usesAnthropicPromptCache(providerId)) return override;
+      return { ...override, messages: stampCacheBreakpoints(override.messages ?? messages) };
+    },
     abortSignal: opts.abortSignal,
     // Bubble each step's completed tool calls up to the parent so its task card
     // shows a live activity list. todo_write is a plan-panel concern, not trace.


### PR DESCRIPTION
## What

Two changes that make long tool-heavy sessions on subscription plans (Volcengine Agent/Coding Plan, Kimi, Z.AI, …) survive provider limits instead of erroring out:

1. **Longer model-call retries** — the SDK default (2 retries, ~6s total backoff) can't outlive a per-minute TPM throttle. Agent-loop calls now retry 10 times (exponential from 2s, deferring to `Retry-After` when the server sends one), so a throttled step resumes on its own instead of surfacing a 429 the user must manually continue. A waiting retry is still cancelled instantly by the turn's abort signal.

2. **Anthropic prompt-cache breakpoints** — Anthropic-protocol caching is opt-in per request and we never sent `cache_control` markers, so every step re-billed the whole growing history as fresh input. Each step's final message view now carries ephemeral breakpoints on its last two messages (the documented incremental-caching pattern); applies to every anthropic-protocol provider. OpenAI-compatible and Gemini endpoints cache prefixes implicitly, so they need no markers — that's why the stamping is protocol-gated.

## Notes

- Rebased onto main after #80 and #83 landed; #83's RetryError unwrapping pairs with the longer retries here.
- Two further changes were built and then shelved by review: a tool-result elision middleware (prefix-cache-invalidation concerns) and a live retry indicator in the chat view; both live on local branches and may return later.
- Verified: `bun run check` clean, 471 main-process tests pass (5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


