### PR TITLE
fix(agent): surface the provider message behind retry failures

### DIFF
--- a/src/main/agent/errors.test.ts
+++ b/src/main/agent/errors.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test';
-import { APICallError } from 'ai';
+import { APICallError, RetryError } from 'ai';
 import { readableError } from './errors';
 
 const apiError = (responseBody?: string): APICallError =>
@@ -9,6 +9,13 @@ const apiError = (responseBody?: string): APICallError =>
     requestBodyValues: {},
     statusCode: 402,
     responseBody,
+  });
+
+const retryError = (...errors: unknown[]): RetryError =>
+  new RetryError({
+    message: `Failed after ${errors.length} attempts. Last error: Too Many Requests`,
+    reason: 'maxRetriesExceeded',
+    errors,
   });
 
 test('digs the provider message out of the response body', () => {
@@ -26,4 +33,16 @@ test('falls back to the SDK message when the body has no error text', () => {
 test('handles plain errors and non-errors', () => {
   expect(readableError(new Error('boom'))).toBe('boom');
   expect(readableError('weird')).toBe('weird');
+});
+
+test('unwraps a retry failure down to the provider message', () => {
+  const last = apiError(JSON.stringify({ error: { message: 'TPM limit exceeded, retry in 60s' } }));
+  const out = readableError(retryError(apiError('Too Many Requests'), last));
+  expect(out).toBe('Failed after 2 attempts. Last error: TPM limit exceeded, retry in 60s');
+});
+
+test('retry failure keeps the SDK message when the last error has no body text', () => {
+  expect(readableError(retryError(apiError(undefined)))).toBe(
+    'Failed after 1 attempts. Last error: sdk fallback message',
+  );
 });

--- a/src/main/agent/errors.ts
+++ b/src/main/agent/errors.ts
@@ -1,4 +1,4 @@
-import { APICallError } from 'ai';
+import { APICallError, RetryError } from 'ai';
 
 /**
  * A human-readable message for the client. createUIMessageStream masks errors
@@ -10,6 +10,12 @@ import { APICallError } from 'ai';
  * rate-limit or exhausted quota), so the original message is the honest signal.
  */
 export function readableError(error: unknown): string {
+  // A retry-exhausted failure only carries the HTTP status text ("Too Many
+  // Requests"); the provider's actual explanation sits in the last underlying
+  // error's response body, so unwrap and dig there.
+  if (RetryError.isInstance(error) && error.lastError !== undefined) {
+    return `Failed after ${error.errors.length} attempts. Last error: ${readableError(error.lastError)}`;
+  }
   if (APICallError.isInstance(error)) {
     if (error.responseBody) {
       try {


### PR DESCRIPTION
## What

"Failed after 3 attempts. Last error: Too Many Requests" told the user nothing — the AI SDK's RetryError message only carries the HTTP status text, while the provider's real explanation (TPM rate limit vs exhausted quota vs …) sits in the last underlying APICallError's response body.

`readableError` now unwraps `RetryError` via its `lastError` and recurses, so the existing body-digging logic applies: `Failed after 3 attempts. Last error: TPM limit exceeded, retry in 60s`. When the body has no message, the output stays what it was today.

## Test plan

- New tests: retry failure unwraps to the provider body message; falls back to the SDK message when the body is empty. `bun test src/main/agent/errors.test.ts` — 5 pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)