### PR TITLE
feat(computer-use): add a setting to hide the virtual cursor

### DIFF
--- a/native/computer-use-helper/ComputerUseNativeHelper.swift
+++ b/native/computer-use-helper/ComputerUseNativeHelper.swift
@@ -109,8 +109,17 @@ final class OverlayCursorController {
 
   // The agent's synthetic pointer. Events are injected via CGEventPostToPid, so
   // the real cursor never moves — this overlay is what the user sees the agent
-  // acting with, and lets them keep using their own mouse meanwhile.
-  private let enabled = true
+  // acting with, and lets them keep using their own mouse meanwhile. The app
+  // can turn it off (a per-request `show_cursor` flag); actions still run.
+  private var enabled = true
+
+  func setEnabled(_ value: Bool) {
+    guard value != enabled else { return }
+    enabled = value
+    if !value {
+      hide()
+    }
+  }
 
   private let size = CGSize(width: 96, height: 96)
   private let hotspot = CGPoint(x: 30.35, y: 48.31)
@@ -2935,6 +2944,10 @@ while let line = readLine() {
   do {
     let request = try decoder.decode(Request.self, from: Data(line.utf8))
     let result: ResultPayload
+
+    if case .bool(let showCursor)? = request.params["show_cursor"] {
+      OverlayCursorController.shared.setEnabled(showCursor)
+    }
 
     switch request.method {
     case "list_apps":

--- a/src/main/agent/tools/builtins/computer-use/output.ts
+++ b/src/main/agent/tools/builtins/computer-use/output.ts
@@ -2,6 +2,7 @@ import type { ImageToolOutput } from '@shared/chat-types';
 import type { HelperResponse } from '../../../../computer-use';
 import { computerPermissions, promptPermissionGrant } from '../../../../computer-use/permissions';
 import { captureWindow } from '../../../../computer-use/screenshot';
+import { getSettings } from '../../../../settings/conf';
 import { spillOversizedImages } from '../../../mcp/spill';
 import type { ToolCtx } from '../../context';
 
@@ -139,7 +140,14 @@ export async function runComputerAction(
     promptPermissionGrant(perms);
     return "Computer use needs Accessibility and Screen Recording permission — they aren't both granted right now. I've opened the grant prompt for the user; ask them to complete it, then try the action again.";
   }
-  const res = await ctx.computerUse.call(method, params, { signal });
+  // The cursor preference rides on every request (read live, so a mid-turn
+  // toggle applies) — a one-shot set would be lost when a timed-out helper is
+  // killed and respawned.
+  const res = await ctx.computerUse.call(
+    method,
+    { ...params, show_cursor: getSettings('computerUse').showVirtualCursor },
+    { signal },
+  );
   const output = await toToolOutput(res, ctx.workspaceRoot);
   if (
     method === 'get_app_state' &&

--- a/src/renderer/src/components/settings/computer/ComputerUseSection.tsx
+++ b/src/renderer/src/components/settings/computer/ComputerUseSection.tsx
@@ -31,9 +31,7 @@ export function ComputerUseSection(): React.JSX.Element {
   const { t } = useTranslation();
   const perms = trpc.computer.permissions.useQuery(undefined, { refetchInterval: 2000 });
   const { value: enabled, set: setEnabled } = useSetting('computerUse.enabled');
-  const { value: menubarStatus, set: setMenubar } = useSetting('computerUse.menubarStatus');
-  const { value: pauseOnInput, set: setPause } = useSetting('computerUse.pauseOnInput');
-  const { value: confirmSensitive, set: setConfirm } = useSetting('computerUse.confirmSensitive');
+  const { value: showCursor, set: setShowCursor } = useSetting('computerUse.showVirtualCursor');
 
   // Off macOS the feature can't run; show a coming-soon note instead of controls.
   if (perms.data && !perms.data.supported) {
@@ -69,43 +67,18 @@ export function ComputerUseSection(): React.JSX.Element {
             <h2 className="mb-3 font-semibold text-fg-primary text-sm">
               {t('settings.computer.behaviorTitle')}
             </h2>
-            <div className="divide-y divide-border-default rounded-xl border border-border-default bg-surface">
+            <div className="rounded-xl border border-border-default bg-surface">
               <div className="flex items-center justify-between gap-6 px-4 py-3.5">
                 <div className="min-w-0">
                   <div className="flex items-center gap-2 font-medium text-fg-primary text-sm">
                     <MousePointerClick className="size-3.5 text-fg-tertiary" />
-                    {t('settings.computer.menubar')}
+                    {t('settings.computer.showCursor')}
                   </div>
                   <div className="mt-0.5 text-fg-tertiary text-xs">
-                    {t('settings.computer.menubarDesc')}
+                    {t('settings.computer.showCursorDesc')}
                   </div>
                 </div>
-                <EnableSwitch on={menubarStatus} onToggle={() => setMenubar(!menubarStatus)} />
-              </div>
-              <div className="flex items-center justify-between gap-6 px-4 py-3.5">
-                <div className="min-w-0">
-                  <div className="font-medium text-fg-primary text-sm">
-                    {t('settings.computer.pause')}
-                  </div>
-                  <div className="mt-0.5 text-fg-tertiary text-xs">
-                    {t('settings.computer.pauseDesc')}
-                  </div>
-                </div>
-                <EnableSwitch on={pauseOnInput} onToggle={() => setPause(!pauseOnInput)} />
-              </div>
-              <div className="flex items-center justify-between gap-6 px-4 py-3.5">
-                <div className="min-w-0">
-                  <div className="font-medium text-fg-primary text-sm">
-                    {t('settings.computer.confirm')}
-                  </div>
-                  <div className="mt-0.5 text-fg-tertiary text-xs">
-                    {t('settings.computer.confirmDesc')}
-                  </div>
-                </div>
-                <EnableSwitch
-                  on={confirmSensitive}
-                  onToggle={() => setConfirm(!confirmSensitive)}
-                />
+                <EnableSwitch on={showCursor} onToggle={() => setShowCursor(!showCursor)} />
               </div>
             </div>
           </section>

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -514,14 +514,10 @@ export const en: typeof zh = {
       runtimeDesc:
         'The AI wants to operate an app but is missing the permissions below. Grant them and it can continue.',
       runtimeLater: 'Later',
-      behaviorTitle: 'Behavior & safety',
-      menubar: 'Show status in the menu bar',
-      menubarDesc:
-        'While the AI acts, a menu-bar icon (target app + cursor) shows what it’s doing; click to stop.',
-      pause: 'Pause when I use the keyboard or mouse',
-      pauseDesc: 'The moment you move the mouse or type, the AI pauses so it doesn’t interfere.',
-      confirm: 'Confirm sensitive actions',
-      confirmDesc: 'Ask before irreversible actions like submit, pay, or delete.',
+      behaviorTitle: 'Behavior',
+      showCursor: 'Show the virtual cursor while acting',
+      showCursorDesc:
+        'Overlay a virtual cursor on the target window to mark where the AI is clicking. Turning it off doesn’t affect the actions.',
     },
     about: {
       description:

--- a/src/renderer/src/i18n/zh.ts
+++ b/src/renderer/src/i18n/zh.ts
@@ -506,7 +506,8 @@ export const zh = {
       runtimeLater: '稍后',
       behaviorTitle: '行为',
       showCursor: '执行中显示虚拟鼠标',
-      showCursorDesc: 'AI 操作时，在目标窗口上显示一个虚拟光标，标出它正在点击的位置。关闭不影响执行。',
+      showCursorDesc:
+        'AI 操作时，在目标窗口上显示一个虚拟光标，标出它正在点击的位置。关闭不影响执行。',
     },
     about: {
       description:

--- a/src/renderer/src/i18n/zh.ts
+++ b/src/renderer/src/i18n/zh.ts
@@ -504,13 +504,9 @@ export const zh = {
       runtimeTitle: '电脑操作需要授权',
       runtimeDesc: 'AI 想操作应用，但还缺少下面的权限。授权后它就能继续。',
       runtimeLater: '稍后',
-      behaviorTitle: '行为与安全',
-      menubar: '在菜单栏显示操作状态',
-      menubarDesc: 'AI 操作时，菜单栏出现「目标应用 + 鼠标」图标显示它在做什么，点击可停止。',
-      pause: '我操作键鼠时立即暂停',
-      pauseDesc: '检测到你在动鼠标或键盘，立刻暂停 AI，避免互相干扰。',
-      confirm: '敏感操作需二次确认',
-      confirmDesc: '提交、支付、删除等不可逆动作执行前，先弹出确认。',
+      behaviorTitle: '行为',
+      showCursor: '执行中显示虚拟鼠标',
+      showCursorDesc: 'AI 操作时，在目标窗口上显示一个虚拟光标，标出它正在点击的位置。关闭不影响执行。',
     },
     about: {
       description:

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -126,12 +126,8 @@ const computerUseShape = z.object({
   /** Master switch for desktop automation (macOS only). Off by default: the
    *  user opts in, and it needs Accessibility + Screen Recording grants. */
   enabled: z.boolean().default(false),
-  /** Show a menu-bar status (target app + cursor) while the AI is acting. */
-  menubarStatus: z.boolean().default(true),
-  /** Pause the agent the moment the user touches the keyboard or mouse. */
-  pauseOnInput: z.boolean().default(true),
-  /** Confirm before irreversible actions (submit / pay / delete). */
-  confirmSensitive: z.boolean().default(true),
+  /** Overlay a virtual cursor on the target window while the AI is acting. */
+  showVirtualCursor: z.boolean().default(true),
 });
 
 // zod v4's `.default` takes the resolved output (not an input run through the


### PR DESCRIPTION
## What

Replaces the three unimplemented "行为与安全" toggles (menu-bar status, pause-on-input, sensitive-action confirm) with a single setting that actually works: **show the virtual cursor while acting** (`computerUse.showVirtualCursor`, default on).

- **Schema**: the three stub keys are removed; stale values in an existing `settings.json` are simply ignored (defaults-merge reads only known fields).
- **Wiring**: `runComputerAction` reads the setting live and sends it as a `show_cursor` flag on **every** helper request — a one-shot set would be lost when a timed-out helper is killed and respawned, and per-request means a mid-turn toggle applies immediately.
- **Helper**: `OverlayCursorController.enabled` becomes settable; the request loop consumes `show_cursor` centrally before dispatch. Turning it off hides the overlay at once; all show paths already guard on the flag. Actions run the same either way.

## Verified

- Standalone helper stdin test: `get_app_state` with `show_cursor:false` → 0 on-screen overlay windows for the helper pid (CGWindowList); `true` → 1; toggling back off mid-stream hides it. PASS.
- Dev app via CDP: the new section renders with the single toggle; clicking it persists `showVirtualCursor` false→true through the tRPC patch path.
- `pnpm typecheck` and the helper build/codesign both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)