### PR TITLE
fix(computer-use): run the helper on macOS 13/14 and add a grant-bar fallback placement

### DIFF
--- a/native/computer-use-helper/build.sh
+++ b/native/computer-use-helper/build.sh
@@ -16,7 +16,12 @@ echo "→ Compiling…"
 rm -rf "$APP"
 mkdir -p "$MACOS"
 cp "$HERE/Info.plist" "$APP/Contents/Info.plist"
-swiftc -O "$HERE/ComputerUseNativeHelper.swift" -o "$MACOS/AtriumComputerUse"
+# Without an explicit -target, swiftc inherits the build machine's OS as the
+# deployment target (CI runners are macOS 15), and the binary then refuses to
+# load on older systems. Pin it to the floor Info.plist promises
+# (LSMinimumSystemVersion 13.0) so the helper runs everywhere the app does.
+swiftc -O -target "$(uname -m)-apple-macos13.0" \
+  "$HERE/ComputerUseNativeHelper.swift" -o "$MACOS/AtriumComputerUse"
 
 # Developer ID when it's reachable (a dev machine's login keychain). In CI the
 # signing keychain isn't imported yet at compile time, so ad-hoc sign instead —

--- a/src/main/computer-use/drag-overlay.ts
+++ b/src/main/computer-use/drag-overlay.ts
@@ -15,6 +15,9 @@ const HEIGHT = 104;
 const FALLBACK_WIDTH = 380;
 const GAP = 12;
 const POLL_MS = 250;
+// Failed Settings lookups tolerated (~2s) before anchored placement is deemed
+// unavailable and the bar shows at a fixed spot instead.
+const FALLBACK_MISSES = 8;
 // System Settings' sidebar is a fixed width; the overlay aligns to the content
 // column on its right, not the whole window, so it never spans the menu.
 const SIDEBAR_WIDTH = 220;
@@ -41,6 +44,11 @@ async function loadIcon(): Promise<void> {
 // while a Space switch is settling so the overlay lands in one hop, not several.
 let appliedKey: string | null = null;
 let pendingKey: string | null = null;
+// Lookup misses since showDragOverlay, and whether Settings was ever located
+// this round — distinguishes "Settings is on another Space" (hide and wait)
+// from "the helper can't find it at all" (fall back to a fixed spot).
+let misses = 0;
+let placedOnce = false;
 
 export interface OverlayTexts {
   heading: string;
@@ -163,11 +171,31 @@ async function syncOverlay(win: BrowserWindow, immediate = false): Promise<void>
   const settings = await settingsBounds();
   if (win.isDestroyed()) return;
   if (!settings) {
-    if (win.isVisible()) win.hide();
-    appliedKey = null;
-    pendingKey = null;
+    if (placedOnce) {
+      if (win.isVisible()) win.hide();
+      appliedKey = null;
+      pendingKey = null;
+      return;
+    }
+    // Settings never located this round: that's not a Space switch, it's the
+    // lookup itself failing (e.g. the helper can't run on this machine). The
+    // drag needs no helper, so after enough misses show the bar bottom-center
+    // of the cursor's display rather than leaving the grant flow invisible.
+    misses += 1;
+    if (misses >= FALLBACK_MISSES && !win.isVisible()) {
+      const area = screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).workArea;
+      win.setBounds({
+        x: Math.round(area.x + (area.width - FALLBACK_WIDTH) / 2),
+        y: area.y + area.height - HEIGHT,
+        width: FALLBACK_WIDTH,
+        height: HEIGHT,
+      });
+      win.showInactive();
+    }
     return;
   }
+  placedOnce = true;
+  misses = 0;
   const target = place(settings);
   const key = `${target.x},${target.y},${target.width}`;
   const reveal = () => {
@@ -248,6 +276,8 @@ export async function showDragOverlay(texts: OverlayTexts): Promise<void> {
   if (process.platform !== 'darwin') return;
   appliedKey = null;
   pendingKey = null;
+  misses = 0;
+  placedOnce = false;
   const win = ensureOverlay();
   void win.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(buildHtml(texts))}`);
   // Get the main window out of the way so System Settings comes to the front:
@@ -256,7 +286,8 @@ export async function showDragOverlay(texts: OverlayTexts): Promise<void> {
   // always-on-top window, so it stays visible; hideDragOverlay brings it back.
   parkMainWindow(true);
   // syncOverlay reveals it only if Settings is already on this Space; otherwise
-  // the follow loop shows it the moment Settings appears here.
+  // the follow loop shows it the moment Settings appears here — or at a fixed
+  // fallback spot once the lookup has clearly failed for good.
   await syncOverlay(win, true);
   startFollow(win);
 }
@@ -265,6 +296,8 @@ export function hideDragOverlay(): void {
   stopFollow();
   appliedKey = null;
   pendingKey = null;
+  misses = 0;
+  placedOnce = false;
   overlay?.hide();
   parkMainWindow(false);
 }


### PR DESCRIPTION
## Problem 1 — helper refuses to load on macOS 13/14

The released computer-use helper binary only loads on macOS 15+. On macOS 13/14, dyld kills it at spawn:

```
dyld: Symbol not found: _$ss20__StaticArrayStorageCN
Referenced from: … AtriumComputerUse (built for macOS 15.0 which is newer than running OS)
```

`build.sh` compiles with `swiftc -O` and no `-target`, so the deployment target silently follows the build machine — the CI macos-15 runners produced a `minos 15.0` binary, while the helper's own `Info.plist` promises `LSMinimumSystemVersion 13.0`.

Impact on macOS 13/14: every helper call dies (screenshots, clicks — all of computer use), and the drag-to-grant overlay never reveals because `get_window_bounds` keeps failing (the helper respawns and dies every 250ms poll tick), so granting permissions looks like "nothing happens".

**Fix:** pin the compile target to the promised floor — `swiftc -O -target "$(uname -m)-apple-macos13.0"`. `uname -m` matches the per-arch native runners (arm64 / x86_64).

## Problem 2 — any lookup failure leaves the grant flow invisible

The overlay only revealed after the helper reported System Settings' window bounds; a persistent failure (like problem 1, or any future helper breakage) kept it hidden forever with zero feedback.

**Fix:** if the lookup has never succeeded since the overlay was requested, show the bar bottom-center of the cursor's display after ~2s — the drag itself doesn't need the helper. Once it has anchored to Settings, a lost lookup still hides the bar (that means Settings moved to another Space, the original behavior).

## Verification

- Both arches compile clean with the 13.0 target; `otool -l` shows `minos 13.0` (was `15.0`).
- Rebuilt helper verified on macOS 26.5 **and on the affected Sonoma 14.7.8 machine** — the binary that previously died with the dyld error now answers `get_window_bounds` normally.
- Fallback verified in the running app (System Settings closed → bar appears bottom-center of the cursor's display after ~2s, correct on a negative-coordinate multi-display layout; opening Settings migrates it to the anchored position below the window; quitting Settings after anchoring hides it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
