### PR TITLE
fix(computer-use): make the virtual cursor show and hide deterministic

### DIFF
--- a/native/computer-use-helper/ComputerUseNativeHelper.swift
+++ b/native/computer-use-helper/ComputerUseNativeHelper.swift
@@ -222,14 +222,12 @@ final class OverlayCursorController {
     } else {
       window.orderFront(nil)
     }
-    if window.alphaValue < 0.98 {
-      NSAnimationContext.runAnimationGroup { context in
-        context.duration = 0.12
-        window.animator().alphaValue = 1
-      }
-    } else {
-      window.alphaValue = 1
-    }
+    // Direct write, never an animator fade: animator-driven alpha only advances
+    // on runloop ticks, which this process can't guarantee (the main thread
+    // blocks on readLine between requests). A stalled fade leaves the cursor
+    // invisible at alpha 0, and one still in flight when hide() runs can tick
+    // afterwards and resurrect a dismissed cursor.
+    window.alphaValue = 1
     currentPoint = point
   }
 
@@ -243,23 +241,29 @@ final class OverlayCursorController {
         self.view?.pulseAlpha = 0
         self.view?.pressed = false
         window.alphaValue = 0
-        window.orderOut(nil)
       }
     }
     hideWorkItem = workItem
     overlayQueue.asyncAfter(deadline: .now() + (delay ?? idleHideDelay), execute: workItem)
   }
 
-  // Collapse the overlay right now, synchronously on the caller's thread. The
-  // idle-hide work item can't do this once a turn ends: it hops to the main
-  // queue, which never drains while the helper blocks on readLine with no
-  // runloop — so the app hides the overlay explicitly at turn end instead.
+  // Collapse the overlay right now, on the caller's thread. The idle-hide work
+  // item can't do this once a turn ends: it hops to the main queue, which never
+  // drains while the helper blocks on readLine with no runloop — so the app
+  // hides the overlay explicitly at turn end instead.
+  //
+  // Alpha-only, no orderOut: after an orderOut, re-ordering the window back in
+  // silently fails in this runloop-less process, leaving every later cursor
+  // invisible. And the alpha write itself only reaches the window server once
+  // the runloop turns — action handlers flush incidentally through their
+  // animation spins, but hide() has none, so it must spin briefly or the write
+  // sits unflushed and the dismissed cursor ghosts on screen indefinitely.
   func hide() {
     cancelHide()
     view?.pulseAlpha = 0
     view?.pressed = false
     window?.alphaValue = 0
-    window?.orderOut(nil)
+    RunLoop.current.run(until: Date().addingTimeInterval(0.05))
     currentPoint = nil
   }
 
@@ -2936,7 +2940,31 @@ func windowBoundsResult(bundleId: String) -> ResultPayload {
   )
 }
 
+// Self-terminate after prolonged idleness. The cursor overlay lives and dies
+// with this process, so even when the app never delivers a hide (crash, forced
+// quit, an update relaunch mid-turn), a stray cursor outlives the last request
+// by at most this window; the app respawns the helper on the next action. This
+// must be a dedicated thread: the main thread blocks on readLine, so nothing
+// scheduled on its queue or runloop would ever fire.
+let idleExitInterval: TimeInterval = 300
+var lastRequestAt = Date()
+let lastRequestLock = NSLock()
+Thread.detachNewThread {
+  while true {
+    Thread.sleep(forTimeInterval: 30)
+    lastRequestLock.lock()
+    let idle = Date().timeIntervalSince(lastRequestAt)
+    lastRequestLock.unlock()
+    if idle > idleExitInterval {
+      exit(0)
+    }
+  }
+}
+
 while let line = readLine() {
+  lastRequestLock.lock()
+  lastRequestAt = Date()
+  lastRequestLock.unlock()
   if line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
     continue
   }

--- a/src/main/computer-use/helper.ts
+++ b/src/main/computer-use/helper.ts
@@ -70,8 +70,10 @@ export class ComputerUseHelper {
         cleanup();
         // A hung request (e.g. a slow accessibility walk on System Settings)
         // blocks the single-threaded helper's next request too, so kill the
-        // child — ensureChild respawns it on the following call.
-        this.child?.kill();
+        // child — ensureChild respawns it on the following call. SIGKILL, not
+        // SIGTERM: a process wedged in a Mach call can defer SIGTERM and live
+        // on (cursor overlay included) after `child` is nulled here.
+        this.child?.kill('SIGKILL');
         this.child = null;
         reject(new Error(`Computer use action timed out after ${timeoutMs}ms.`));
       }, timeoutMs);
@@ -98,7 +100,7 @@ export class ComputerUseHelper {
 
   dispose(): void {
     if (this.child) {
-      this.child.kill();
+      this.child.kill('SIGKILL');
       this.child = null;
     }
     this.rejectAll(new Error('Computer Use helper disposed.'));
@@ -114,7 +116,9 @@ export class ComputerUseHelper {
     if (!this.child) {
       return;
     }
-    void this.call('hide_overlay').catch(() => {});
+    void this.call('hide_overlay').catch((error) => {
+      log.warn('hide_overlay failed', error);
+    });
   }
 
   private ensureChild(): ChildProcessWithoutNullStreams {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,6 +12,7 @@ import { runDream, startDreamScheduler } from './agent/memory';
 import { populateModelCatalog, startModelCatalogRefresh } from './agent/models/catalog';
 import { scheduledManager, startScheduledTasks } from './agent/scheduled';
 import { refreshSkills } from './agent/skills/registry';
+import { disposeComputerUseHelper } from './computer-use';
 import { registerComputerUseDrag } from './computer-use/drag';
 import { registerDragOverlay } from './computer-use/drag-overlay';
 import { registerPermissionBridge } from './computer-use/permissions';
@@ -159,6 +160,9 @@ app.whenReady().then(async () => {
     getWindow: () => mainWindow,
     onBeforeInstall: () => {
       isQuitting = true;
+      // Kill the helper before the update relaunch: a mid-request child would
+      // survive the swap as an orphan still showing its cursor overlay.
+      disposeComputerUseHelper();
     },
   });
   updaterManager.startAutoCheck();
@@ -270,5 +274,6 @@ app.on('before-quit', () => {
   scheduledManager.dispose();
   void mcpManager.dispose();
   updaterManager.dispose();
+  disposeComputerUseHelper();
   closeDb();
 });

--- a/src/main/trpc/routers/computer.ts
+++ b/src/main/trpc/routers/computer.ts
@@ -1,6 +1,7 @@
 import { PRIVACY_PANES } from '@shared/computer-use';
 import { app, shell } from 'electron';
 import { z } from 'zod';
+import { disposeComputerUseHelper } from '../../computer-use';
 import { hideDragOverlay, showDragOverlay } from '../../computer-use/drag-overlay';
 import { computerPermissions } from '../../computer-use/permissions';
 import { publicProcedure, router } from '../trpc';
@@ -26,6 +27,10 @@ export const computerRouter = router({
    * the app restarts, so the drag-to-grant flow calls this once both grants land.
    */
   relaunch: publicProcedure.mutation(() => {
+    // app.exit skips before-quit, so kill the helper here — the grant flow's
+    // overlay was polling it moments ago, and an orphaned child would keep
+    // its cursor overlay on screen across the relaunch.
+    disposeComputerUseHelper();
     app.relaunch();
     app.exit(0);
   }),


### PR DESCRIPTION
## Problem

The virtual cursor sometimes stays on screen after a computer-use task ends (Haoze reproduced on macOS 14.7.8: healthy helper process, parent alive, cursor ghosting), and sometimes never becomes properly visible during actions (reproduced on macOS 26: window-server alpha stuck at 0 through entire tasks — likely why the ghost cursor looked so faint it was missed at first).

Root cause, established empirically by driving the shipped helper binary directly and sampling `kCGWindowAlpha`: **NSWindow property writes from the helper only commit to the window server when its runloop turns, and the helper's main thread blocks on `readLine` between requests.**

- The cursor fade-in used an `NSAnimationContext` animator that needs runloop ticks — it could stall at alpha 0 (invisible cursor).
- `hide_overlay`'s `alphaValue = 0` write sat unflushed because the hide handler returns straight to `readLine` — the dismissed cursor ghosts on screen indefinitely. Action handlers never hit this only because their movement animations spin the runloop incidentally.
- Bonus trap found while fixing: a window that has been `orderOut`-ed from this runloop-less process can't be re-ordered back in — hiding via orderOut would make every subsequent cursor invisible.

## Fix (helper)

- Draw with a direct `alphaValue = 1` write (no animator).
- Hide with `alphaValue = 0` + an explicit 50ms runloop spin to flush; keep the window ordered (alpha-only toggling).
- Idle watchdog thread: the process exits after 5 minutes without requests, so a stray cursor can outlive a missed hide (app crash, forced quit) by at most that window. It must be a thread — nothing scheduled on the blocked main thread ever fires. The app respawns the helper on the next action.

## Fix (main process)

- `disposeComputerUseHelper()` (previously defined but never called) now runs on `before-quit`, before the grant-flow `app.relaunch()` (`app.exit` skips before-quit), and before update install.
- Kills use SIGKILL — a process wedged in a Mach call defers SIGTERM and lives on, cursor included, after the app nulls its handle.
- A failed turn-end `hide_overlay` is logged instead of silently swallowed.

## Verification

Driving the built helper directly, three consecutive show/hide cycles: window-server alpha reads `1.0` after every draw and `0.0` after every hide, steady after 3s (shipped binary: stuck at `0.0` throughout on macOS 26, and hide-then-redraw broke under the orderOut variant). Watchdog verified with shortened intervals: stays alive under request traffic, exits code 0 after going idle. `minos 13.0` preserved. tsc + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)