### PR TITLE
fix(computer-use): don't show the cursor for list_apps

### DIFF
--- a/native/computer-use-helper/ComputerUseNativeHelper.swift
+++ b/native/computer-use-helper/ComputerUseNativeHelper.swift
@@ -986,11 +986,11 @@ func isLikelyUserFacingApp(_ app: NSRunningApplication, visiblePIDs: Set<pid_t>,
   return true
 }
 
+// No cursor here: listing apps is pure observation of nothing in particular,
+// and revealing the overlay at the FRONTMOST window's center made it pop up
+// over whatever the user was doing before the agent had touched any target.
+// The cursor first appears once a request actually addresses an app.
 func listAppsResult() -> ResultPayload {
-  if let target = frontmostActivityTarget() {
-    revealObservationPoint(entry: target.entry, point: target.point)
-  }
-
   let frontmostPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
   let visiblePIDs = Set(windowEntries().map(\.pid))
   let metadataByBundleId = appMetadataIndex()
@@ -1146,7 +1146,7 @@ func listAppsResult() -> ResultPayload {
     return "\(name) — \(bundleText) [\(flags.joined(separator: ", "))]"
   }.joined(separator: "\n")
 
-  let result = ResultPayload(
+  return ResultPayload(
     ok: true,
     toolName: "list_apps",
     app: nil,
@@ -1157,8 +1157,6 @@ func listAppsResult() -> ResultPayload {
     meta: MetaPayload(observedShape: "text", rawText: rawText),
     error: nil
   )
-  OverlayCursorController.shared.extendVisibility()
-  return result
 }
 
 func resolveApp(_ ref: String) -> NSRunningApplication? {
@@ -1203,17 +1201,6 @@ func resolvedWindowInfo(appRef: String) -> WindowEntry? {
 
 func windowCenter(_ entry: WindowEntry) -> CGPoint {
   CGPoint(x: entry.bounds.midX, y: entry.bounds.midY)
-}
-
-func frontmostActivityTarget() -> (entry: WindowEntry?, point: CGPoint)? {
-  if let frontmost = NSWorkspace.shared.frontmostApplication,
-    let entry = windowInfo(for: frontmost.processIdentifier)
-  {
-    return (entry, windowCenter(entry))
-  }
-
-  let mouse = displayPoint(fromAppKitPoint: NSEvent.mouseLocation)
-  return (nil, mouse)
 }
 
 func revealObservationPoint(entry: WindowEntry?, point: CGPoint, wiggle: Bool = true) {


### PR DESCRIPTION
## Problem

Asking the agent to work in an app (e.g. Typora) made the virtual cursor appear in the middle of the screen while the agent was still at the list-apps step — before it had touched any target. `listAppsResult()` deliberately revealed the overlay at the **frontmost** window's center as an "agent is active" indicator, which reads as an unrelated cursor popping up over whatever the user was doing.

## Fix

`list_apps` is pure observation and no longer draws the cursor (the dead `frontmostActivityTarget()` helper is removed with it). The cursor's first appearance is now always target-directed: `get_app_state` reading the target window, or an actual action on it.

## Verification

Driving the built helper directly: `list_apps` creates no overlay window at all; `get_app_state` still reveals the cursor at the target window's center (window-server alpha 1.0) and `hide_overlay` still dismisses it (alpha 0.0) — the deterministic show/hide from #96 intact on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)