### PR TITLE
fix(chat): send composer attachments in the engine's content vocabulary

### DIFF
--- a/src/main/agent/pi/attachments.test.ts
+++ b/src/main/agent/pi/attachments.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from 'bun:test';
+import type { Message } from '@shared/protocol';
+import { withModelAttachments } from './attachments';
+
+const userWith = (...content: unknown[]): Message =>
+  ({ role: 'user', content, timestamp: 0 }) as unknown as Message;
+
+const contentOf = (message: Message): Record<string, unknown>[] =>
+  (message as unknown as { content: Record<string, unknown>[] }).content;
+
+const b64 = (s: string): string => Buffer.from(s, 'utf8').toString('base64');
+
+test('an image attachment becomes engine image content', () => {
+  const out = withModelAttachments(
+    userWith(
+      { type: 'text', text: 'what is this?' },
+      {
+        type: 'file',
+        url: 'data:image/png;base64,QUFBQQ==',
+        mediaType: 'image/png',
+        filename: 'shot.png',
+      },
+    ),
+  );
+  expect(contentOf(out)).toEqual([
+    { type: 'text', text: 'what is this?' },
+    { type: 'image', data: 'QUFBQQ==', mimeType: 'image/png' },
+  ]);
+});
+
+test('a text attachment is decoded and labelled, not left as base64', () => {
+  const out = withModelAttachments(
+    userWith({
+      type: 'file',
+      url: `data:text/plain;base64,${b64('export const x = 1;')}`,
+      mediaType: 'text/plain',
+      filename: 'x.ts',
+    }),
+  );
+  const [part] = contentOf(out);
+  expect(part.type).toBe('text');
+  expect(part.text).toBe('<attachment name="x.ts">\nexport const x = 1;\n</attachment>');
+});
+
+test('a type the engine cannot carry becomes a note naming the file', () => {
+  const out = withModelAttachments(
+    userWith({
+      type: 'file',
+      url: 'data:application/pdf;base64,JVBERi0=',
+      mediaType: 'application/pdf',
+      filename: 'spec.pdf',
+    }),
+  );
+  const [part] = contentOf(out);
+  expect(part.type).toBe('text');
+  expect(part.text).toContain('spec.pdf');
+  expect(part.text).toContain('application/pdf');
+  // The payload must not ride along as text — that is what blew the request up.
+  expect(part.text).not.toContain('JVBERi0=');
+});
+
+test('a non-data url degrades to a note instead of an empty image block', () => {
+  const out = withModelAttachments(
+    userWith({
+      type: 'file',
+      url: 'https://example.com/a.png',
+      mediaType: 'image/png',
+      filename: 'a.png',
+    }),
+  );
+  expect(contentOf(out)[0].type).toBe('text');
+});
+
+test('messages without attachments are returned untouched', () => {
+  const message = userWith({ type: 'text', text: 'hi' });
+  expect(withModelAttachments(message)).toBe(message);
+});
+
+test('a string-content message is left alone', () => {
+  const message = { role: 'user', content: 'hi', timestamp: 0 } as unknown as Message;
+  expect(withModelAttachments(message)).toBe(message);
+});

--- a/src/main/agent/pi/attachments.ts
+++ b/src/main/agent/pi/attachments.ts
@@ -1,0 +1,63 @@
+import type { Content, Message } from '@shared/protocol';
+
+/**
+ * The composer stores an attachment as a UI file part — name, media type and a
+ * self-contained data URL — so a reloaded thread can rebuild its chip without
+ * the original file. The engine's content vocabulary has no such member: its
+ * block mapper treats every non-text content as an image and reads `mimeType`
+ * and `data`, so a file part arrives at the provider as an image with both
+ * fields empty and the whole request is rejected.
+ *
+ * Attachments are therefore translated on the way to the model and only there.
+ * The stored row keeps the shape the renderer round-trips, which also means
+ * threads written before this conversion existed need no migration.
+ */
+
+type FilePart = { type: 'file'; url?: string; mediaType?: string; filename?: string };
+
+const isFilePart = (content: unknown): content is FilePart =>
+  typeof content === 'object' &&
+  content !== null &&
+  (content as { type?: unknown }).type === 'file';
+
+/** The base64 payload of a data URL, or null for any other URL form. */
+function payloadOf(url: string | undefined): string | null {
+  if (!url?.startsWith('data:')) return null;
+  const comma = url.indexOf(',');
+  return comma === -1 ? null : url.slice(comma + 1);
+}
+
+const describe = (part: FilePart): string =>
+  `${part.filename ?? 'attachment'} (${part.mediaType ?? 'unknown type'})`;
+
+const note = (text: string): Content => ({ type: 'text', text }) as Content;
+
+/**
+ * One attachment as content the model can actually read. Images go multimodal.
+ * Text-classified files (the composer reads code, markdown and svg as text) are
+ * decoded and labelled, since their bytes are only useful as source. Anything
+ * else — a PDF today — has no representation in the engine's content union, so
+ * it becomes a note naming the file: the model can then say what it can't read
+ * instead of the turn failing.
+ */
+function toModelContent(part: FilePart): Content {
+  const data = payloadOf(part.url);
+  const mimeType = part.mediaType;
+  if (data === null || !mimeType) return note(`[attachment ${describe(part)} could not be read]`);
+  if (mimeType.startsWith('image/')) return { type: 'image', data, mimeType } as Content;
+  if (mimeType.startsWith('text/')) {
+    const text = Buffer.from(data, 'base64').toString('utf8');
+    return note(`<attachment name="${part.filename ?? 'file'}">\n${text}\n</attachment>`);
+  }
+  return note(`[attachment ${describe(part)} — this model cannot read this file type]`);
+}
+
+/** The same message with every attachment converted; untouched when it has none. */
+export function withModelAttachments(message: Message): Message {
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content) || !content.some(isFilePart)) return message;
+  return {
+    ...message,
+    content: content.map((part) => (isFilePart(part) ? toModelContent(part) : part)),
+  } as Message;
+}

--- a/src/main/server/persist.ts
+++ b/src/main/server/persist.ts
@@ -3,6 +3,7 @@ import type { AtriumUIMessage } from '@shared/chat';
 import type { Message } from '@shared/protocol';
 
 import { asc, eq, or } from 'drizzle-orm';
+import { withModelAttachments } from '../agent/pi/attachments';
 import type { Checkpoint } from '../agent/pi/compaction';
 import { sealDanglingToolCalls } from '../agent/pi/history';
 import type { Db } from '../db';
@@ -181,7 +182,7 @@ export function loadThreadHistory(db: Db, threadId: string): HistoryEntry[] {
       for (const piRow of splitAssistantMessage(legacy))
         out.push({ id: row.id, message: piRow.message });
   }
-  return sealHistory(out);
+  return sealHistory(out).map((e) => ({ ...e, message: withModelAttachments(e.message) }));
 }
 
 export function loadThreadAgentMessages(db: Db, threadId: string): Message[] {


### PR DESCRIPTION
## 问题

输入框附件（粘贴或 `+` 选择）会让整个请求 400 失败，**所有 provider、所有附件类型**：

```
messages.0.content.4.image.source.base64.media_type: Field required
```

附件在存储层是一个 UI file part（`{ type:'file', url:'data:…', mediaType, filename }`——渲染附件 chip 需要它自包含），过去原样透传给引擎。而引擎的 content→block 映射是 `if text … else → image block`，**是 else 而不是类型判断**，于是这个 part 被当成图片、去读 `mimeType` / `data` 两个它没有的字段，两个都是 undefined，请求被服务端直接拒绝。

## 改动

只在**送往模型的路径上**转换（`loadThreadHistory`），存储行保持原样 —— 附件 chip 的回显依赖它，历史线程也因此不需要迁移。

| 附件类型 | 转成 |
|---|---|
| 图片（png/jpeg/gif/webp） | `{ type:'image', data, mimeType }` |
| 文本类（代码 / markdown / svg，输入框按 `text/plain` 归类） | 解码后带文件名标签的文本 —— 这些文件的字节只有作为源码才有用 |
| PDF | 一条点名文件的说明 —— 引擎的 content 联合类型里**没有** document 成员，无法真正发送；这样模型能说"我读不了"而不是整个 turn 挂掉 |

非 data URL 的 file part 同样降级为说明，不再变成空的 image block。

## 验证

真实 app 端到端（CDP 合成 `ClipboardEvent` 粘贴）：

- **图片**：现场生成一张写着随机 6 位数的 PNG → 模型答出 `971067` ✅
- **文本**：`marker.ts` 里放随机常量 → 模型答出 `ZK255276` ✅
- **回显**：刷新后附件 chip 仍在（存储形状未变）✅

外加 6 个单元测试覆盖四条分支 + 无附件短路；`bun run check` 绿，573 测试全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsFA5TauSr9tLaizTUqSPp
