### PR TITLE
refactor(server): rebuild the run path around a composition root

### DIFF
--- a/src/main/agent/pi/approvals.ts
+++ b/src/main/agent/pi/approvals.ts
@@ -4,10 +4,12 @@ import type {
   Message,
   TextContent,
   ToolCall,
+  ToolDecision,
   ToolResultMessage,
 } from '@shared/protocol';
 import { createLogger } from '../../log';
 import type { AtriumTool } from '../tools';
+import type { RunRow } from './recorder';
 
 const log = createLogger('approval');
 
@@ -25,10 +27,7 @@ export type ParkedCall = {
 };
 
 /** What the user came back with for a parked call. */
-export type Resolution =
-  | { toolCallId: string; kind: 'approved' }
-  | { toolCallId: string; kind: 'denied'; reason?: string }
-  | { toolCallId: string; kind: 'answered'; output: unknown };
+export type Resolution = ToolDecision;
 
 const DENIED_TEXT = 'The user denied this call. Do not retry it; adjust your approach.';
 
@@ -72,6 +71,42 @@ function resultMessage(
 }
 
 /**
+ * The decisions that still apply, given what the run actually stored. The rows
+ * are the authority: a call the client claims to have answered may already have
+ * a result (a double-click, a stale view) or may not exist at all, and either
+ * would put a second result on the transcript.
+ */
+export function openResolutions(rows: RunRow[], decisions: Resolution[]): Resolution[] {
+  if (decisions.length === 0) return [];
+  const answered = new Set(rows.flatMap((r) => (r.role === 'toolResult' ? [r.id] : [])));
+  const calls = toolCallsById(rows.map((r) => r.message));
+  return decisions.filter((d) => calls.has(d.toolCallId) && !answered.has(d.toolCallId));
+}
+
+/**
+ * The result a decision settles a call with, or null for an approval — that one
+ * has to run the tool, which only `applyResolutions` can do.
+ */
+export function resultFor(call: ToolCall, resolution: Resolution): ToolResultMessage | null {
+  if (resolution.kind === 'denied') {
+    const reason = resolution.reason?.trim() || DENIED_TEXT;
+    return resultMessage(call, {
+      content: text(reason),
+      details: { denied: true, errorText: reason },
+      isError: true,
+    });
+  }
+  if (resolution.kind === 'answered') {
+    return resultMessage(call, {
+      content: text(stringify(resolution.output)),
+      details: resolution.output,
+      isError: false,
+    });
+  }
+  return null;
+}
+
+/**
  * Settle the calls the user has now decided, before the loop resumes. An
  * approved call runs here rather than inside the loop: the engine only executes
  * calls from the turn it is currently streaming, and this one belongs to a turn
@@ -101,26 +136,9 @@ export async function applyResolutions(opts: {
       continue;
     }
 
-    if (resolution.kind === 'denied') {
-      const reason = resolution.reason?.trim() || DENIED_TEXT;
-      out.push(
-        resultMessage(call, {
-          content: text(reason),
-          details: { denied: true, errorText: reason },
-          isError: true,
-        }),
-      );
-      continue;
-    }
-
-    if (resolution.kind === 'answered') {
-      out.push(
-        resultMessage(call, {
-          content: text(stringify(resolution.output)),
-          details: resolution.output,
-          isError: false,
-        }),
-      );
+    const settled = resultFor(call, resolution);
+    if (settled) {
+      out.push(settled);
       continue;
     }
 

--- a/src/main/agent/pi/emitter.ts
+++ b/src/main/agent/pi/emitter.ts
@@ -1,0 +1,45 @@
+import type { AgentEvent } from '@earendil-works/pi-agent-core';
+import type { AgentSessionEvent } from '@shared/protocol';
+import type { ParkedCall } from './approvals';
+import { projectAgentEvent } from './projector';
+import { withErrorText } from './tool-result';
+
+/**
+ * Put a run's engine events on the wire. Everything here is a decision about
+ * what a *reader* should see, which is why it is separate from what the run
+ * stores: the two disagree on purpose in a couple of places.
+ */
+export function wireEmitter(opts: {
+  runId: string;
+  /** Calls handed back to the user; their cards are showing the ask. */
+  parked: Map<string, ParkedCall>;
+  emit: (event: AgentSessionEvent) => void;
+}): (event: AgentEvent) => void {
+  return (event: AgentEvent) => {
+    // The run emits its own agent_end once its bookkeeping is done, so that the
+    // wire's promise — agent_end is the last event — stays literally true.
+    if (event.type === 'agent_end') return;
+    const projected = projectAgentEvent(event, opts.runId);
+    if (!projected) return;
+    // pi announces every appended message; only assistant turns belong on the
+    // wire — tool results arrive as tool_execution_end, and the user's message
+    // is what started the run.
+    if (
+      (projected.type === 'message_start' || projected.type === 'message_end') &&
+      projected.message.role !== 'assistant'
+    ) {
+      return;
+    }
+    if (projected.type === 'tool_execution_end') {
+      // A parked call produced no result — the card is showing the ask, and a
+      // refusal frame would replace it with an error the user never caused.
+      if (opts.parked.has(projected.toolCallId)) return;
+      projected.result.details = withErrorText(
+        projected.result.details,
+        projected.result.content,
+        projected.isError,
+      );
+    }
+    opts.emit(projected);
+  };
+}

--- a/src/main/agent/pi/history.test.ts
+++ b/src/main/agent/pi/history.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from 'bun:test';
+import type { AssistantMessage, Message, ToolResultMessage } from '@shared/protocol';
+import { sealDanglingToolCalls, withSettledResults } from './history';
+
+const zeroUsage = () => ({
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+});
+
+const calling = (...ids: string[]): AssistantMessage => ({
+  role: 'assistant',
+  content: ids.map((id) => ({ type: 'toolCall', id, name: 'ask_clarification', arguments: {} })),
+  api: 'a',
+  provider: 'p',
+  model: 'm',
+  usage: zeroUsage(),
+  stopReason: 'toolUse',
+  timestamp: 2,
+});
+
+const answer = (toolCallId: string, text: string): ToolResultMessage => ({
+  role: 'toolResult',
+  toolCallId,
+  toolName: 'ask_clarification',
+  content: [{ type: 'text', text }],
+  details: text,
+  isError: false,
+  timestamp: 3,
+});
+
+const resultsFor = (messages: Message[], id: string): ToolResultMessage[] =>
+  messages.filter((m): m is ToolResultMessage => m.role === 'toolResult' && m.toolCallId === id);
+
+test('an unanswered call is sealed so the transcript stays valid', () => {
+  const sealed = sealDanglingToolCalls([calling('c1')]);
+  expect(resultsFor(sealed, 'c1')).toHaveLength(1);
+  expect(resultsFor(sealed, 'c1')[0].isError).toBe(true);
+});
+
+test('a settled decision replaces the seal rather than joining it', () => {
+  // What a resumed run actually starts from: the reader has already sealed the
+  // call the previous turn parked, and now the user's answer arrives for it.
+  const history = sealDanglingToolCalls([calling('c1')]);
+  const messages = withSettledResults(history, [answer('c1', 'blue')]);
+
+  const results = resultsFor(messages, 'c1');
+  expect(results).toHaveLength(1);
+  expect(results[0].details).toBe('blue');
+  // The answer has to sit after the turn that asked for it.
+  expect(messages.at(-1)).toBe(results[0]);
+});
+
+test('results for other calls are left where they are', () => {
+  const history: Message[] = [calling('c1', 'c2'), answer('c1', 'kept')];
+  const messages = withSettledResults(history, [answer('c2', 'new')]);
+  expect(resultsFor(messages, 'c1')).toHaveLength(1);
+  expect(resultsFor(messages, 'c2')).toHaveLength(1);
+  expect(messages).toHaveLength(3);
+});
+
+test('nothing settled leaves the transcript untouched', () => {
+  const history: Message[] = [calling('c1')];
+  expect(withSettledResults(history, [])).toBe(history);
+});

--- a/src/main/agent/pi/history.ts
+++ b/src/main/agent/pi/history.ts
@@ -46,6 +46,23 @@ export function sealDanglingToolCalls(messages: Message[]): Message[] {
 }
 
 /**
+ * Fold freshly settled results into a transcript, dropping any placeholder it
+ * already carried for the same calls.
+ *
+ * A parked call has no result row, so reading the thread back seals it as
+ * "stopped before the tool returned" — right for a turn nobody is coming back
+ * to, wrong the moment the user's answer does arrive. Appending the real result
+ * next to the placeholder gives one call two results, which every provider
+ * rejects outright, so the placeholder has to go.
+ */
+export function withSettledResults(messages: Message[], settled: ToolResultMessage[]): Message[] {
+  if (settled.length === 0) return messages;
+  const ids = new Set(settled.map((m) => m.toolCallId));
+  const kept = messages.filter((m) => m.role !== 'toolResult' || !ids.has(m.toolCallId));
+  return [...kept, ...settled];
+}
+
+/**
  * Prepend a `<system-reminder>` to a user message — on the message rather than
  * the system prompt, so the cached system prefix stays byte-stable.
  *

--- a/src/main/agent/pi/recorder.ts
+++ b/src/main/agent/pi/recorder.ts
@@ -1,0 +1,193 @@
+import type { AgentEvent } from '@earendil-works/pi-agent-core';
+import type { AssistantMessage, Message, ToolCall } from '@shared/protocol';
+import type { ParkedCall } from './approvals';
+import { withErrorText } from './tool-result';
+import { storedMessage } from './vocabulary';
+
+/** One pi message a run produced, ready to be stored as its own row. */
+export type RunRow = {
+  id: string;
+  role: 'assistant' | 'toolResult';
+  message: Message;
+  metadata?: Record<string, unknown> | null;
+};
+
+/** What the run's model calls spent, summed across its turns. */
+export type RunTotals = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  total: number;
+};
+
+export type RunRecorder = {
+  /** Fold one engine event into the run's accumulated state. */
+  observe(event: AgentEvent): void;
+  /**
+   * The rows to store, with the run's metadata on the first one. Closes every
+   * unanswered call first, so the result is safe to read back as history.
+   */
+  finalize(metadata: Record<string, unknown>): RunRow[];
+  readonly totals: RunTotals;
+  /** The prompt size at the last turn's end — compaction's counting base. */
+  readonly contextTokens: number | undefined;
+  /** Set when a turn ended in a provider error. */
+  readonly failure: string | undefined;
+};
+
+const isAssistant = (m: Message): m is AssistantMessage => m.role === 'assistant';
+
+/** What a finished turn actually put in front of the model, cached parts included. */
+const contextSizeOf = (usage: AssistantMessage['usage']): number =>
+  usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+
+/**
+ * Accumulates a run's messages as the rows it will be stored as.
+ *
+ * Storing at the end rather than per event is deliberate: a run is one stored
+ * unit (its rows are replaced together, keeping the group's position when a
+ * continuation extends it), and the run-level metadata a reader needs — how
+ * long the turn took, what it cost — only exists once the turn is over.
+ */
+export function createRunRecorder(opts: {
+  runId: string;
+  /** Calls handed back to the user: they get no result row this run. */
+  parked: Map<string, ParkedCall>;
+  /** Rows this run stored earlier, when the turn is a continuation. */
+  seed?: RunRow[];
+}): RunRecorder {
+  const rows: RunRow[] = [...(opts.seed ?? [])];
+  const totals: RunTotals = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+  let contextTokens: number | undefined;
+  let failure: string | undefined;
+
+  return {
+    observe(event: AgentEvent): void {
+      if (event.type !== 'message_end') return;
+      const message = storedMessage(event.message);
+
+      if (isAssistant(message)) {
+        // A provider failure ends the turn as an errored assistant message
+        // rather than an exception, so this is the only place a caller that
+        // isn't reading the stream can learn the run failed.
+        if (message.stopReason === 'error') {
+          failure = message.errorMessage ?? 'the model call failed';
+        }
+        const usage = message.usage;
+        totals.input += usage.input;
+        totals.output += usage.output;
+        totals.cacheRead += usage.cacheRead;
+        totals.cacheWrite += usage.cacheWrite;
+        totals.total += usage.totalTokens;
+        // The prompt at turn end — the honest base for compaction's threshold,
+        // where the cumulative figure would count a tool loop many times over.
+        // Not `input + output`: a cached prompt bills only its uncached part to
+        // `input`, so that pair reads as a fraction of what was actually sent.
+        contextTokens = contextSizeOf(usage);
+        // A turn that produced nothing (the provider errored before its first
+        // block) is not stored: an empty content list is rejected outright when
+        // it comes back as history, which would wedge the thread for good.
+        if (message.content.length > 0) {
+          rows.push({
+            id: `${opts.runId}:${rows.filter((r) => r.role === 'assistant').length}`,
+            role: 'assistant',
+            message,
+          });
+        }
+        return;
+      }
+
+      if (message.role === 'toolResult') {
+        // A parked call is stored as still open, so a reload shows the ask again
+        // and the decision can still land on it.
+        if (opts.parked.has(message.toolCallId)) return;
+        message.details = withErrorText(message.details, message.content, message.isError);
+        rows.push({ id: message.toolCallId, role: 'toolResult', message });
+      }
+    },
+
+    finalize(metadata: Record<string, unknown>): RunRow[] {
+      if (rows.length === 0) return rows;
+      stampParkedCalls(rows, opts.parked);
+      sealUnansweredCalls(rows, opts.parked);
+      rows[0].metadata = { ...rows[0].metadata, ...metadata };
+      return rows;
+    },
+
+    get totals() {
+      return totals;
+    },
+    get contextTokens() {
+      return contextTokens;
+    },
+    get failure() {
+      return failure;
+    },
+  };
+}
+
+/**
+ * Record each parked call's pending state on the turn that made it. The row
+ * vocabulary has no slot for "waiting on the user" — a call is open or it has a
+ * result — so the UI state rides in the row's metadata, which is where every
+ * other tool-state extra already lives.
+ */
+function stampParkedCalls(rows: RunRow[], parked: Map<string, ParkedCall>): void {
+  if (parked.size === 0) return;
+  for (const row of rows) {
+    if (row.message.role !== 'assistant') continue;
+    const states: Record<string, unknown> = {};
+    for (const content of row.message.content) {
+      if (content.type !== 'toolCall') continue;
+      const call = parked.get((content as ToolCall).id);
+      if (!call) continue;
+      states[call.toolCallId] = call.approvalId
+        ? { state: 'approval-requested', approval: { id: call.approvalId } }
+        : { state: 'input-available' };
+    }
+    if (Object.keys(states).length === 0) continue;
+    const existing = (row.metadata?.toolStates ?? {}) as Record<string, unknown>;
+    row.metadata = { ...row.metadata, toolStates: { ...existing, ...states } };
+  }
+}
+
+const SEAL_ERROR = 'Stopped before the tool returned.';
+
+/**
+ * Give every tool call a result row. A stopped turn leaves its in-flight call
+ * unanswered, and both the provider (which rejects an unpaired tool call in the
+ * history) and the card (which would sit spinning forever) need it closed.
+ */
+function sealUnansweredCalls(rows: RunRow[], parked: Map<string, ParkedCall>): void {
+  const answered = new Set([
+    ...parked.keys(),
+    ...rows.flatMap((row) => (row.role === 'toolResult' ? [row.id] : [])),
+  ]);
+  const sealed: RunRow[] = [];
+  for (const row of rows) {
+    sealed.push(row);
+    if (row.message.role !== 'assistant') continue;
+    for (const content of row.message.content) {
+      if (content.type !== 'toolCall') continue;
+      const call = content as ToolCall;
+      if (answered.has(call.id)) continue;
+      answered.add(call.id);
+      sealed.push({
+        id: call.id,
+        role: 'toolResult',
+        message: {
+          role: 'toolResult',
+          toolCallId: call.id,
+          toolName: call.name,
+          content: [{ type: 'text', text: SEAL_ERROR }],
+          details: { errorText: SEAL_ERROR },
+          isError: true,
+          timestamp: row.message.timestamp,
+        },
+      });
+    }
+  }
+  rows.length = 0;
+  rows.push(...sealed);
+}

--- a/src/main/agent/pi/runtime.ts
+++ b/src/main/agent/pi/runtime.ts
@@ -1,0 +1,101 @@
+import {
+  Agent,
+  type AgentEvent,
+  type AgentOptions,
+  type StreamFn,
+} from '@earendil-works/pi-agent-core';
+import type { Api, Model } from '@earendil-works/pi-ai';
+import type { Message } from '@shared/protocol';
+import { currentDateNote } from '../prompts';
+import type { AtriumTool } from '../tools';
+import { type ContextTransform, composeContext } from './context';
+import { injectSystemReminder } from './history';
+import { createLoopDetector } from './loop-detection';
+import { asPi } from './vocabulary';
+
+/** Complex work routinely runs a dozen turns; this is the runaway brake. */
+const MAX_TURNS = 100;
+
+export type AgentRuntimeOptions = {
+  systemPrompt: string;
+  model: Model<Api>;
+  streamFn: StreamFn;
+  getApiKey: (provider: string) => string | undefined;
+  /** The transcript the loop starts from. */
+  messages: Message[];
+  tools: AtriumTool[];
+  /**
+   * Rewrites of the model's view, in the order they apply. The date note and
+   * the loop notice are appended after them: the date must land on the current
+   * turn before any notice can claim that anchor, and the loop notice goes last
+   * so it sits closest to what the model is about to answer.
+   */
+  transforms?: (ContextTransform | false | undefined)[];
+  /** The tools to offer for the next turn; defaults to the full set. */
+  toolsForNextTurn?: () => AtriumTool[];
+  /** A further reason to end the run after the current turn. */
+  stopAfterTurn?: () => boolean;
+  beforeToolCall?: AgentOptions['beforeToolCall'];
+};
+
+export type AgentRuntime = {
+  subscribe(listener: (event: AgentEvent) => void): void;
+  /** Run to completion, forwarding an outer stop to the engine. Errors from the
+   *  loop itself propagate — what to do about one differs per caller. */
+  run(signal?: AbortSignal): Promise<void>;
+};
+
+/**
+ * An Atrium agent loop: pi's `Agent` plus the wiring every loop in the app
+ * shares — the context pipeline, the repetition brake, the turn cap and stop
+ * forwarding. The chat turn and a subagent differ in what they put in front of
+ * the model and what they do with its events, not in how the loop is built, so
+ * only those differences are passed in.
+ *
+ * The repetition brake lives here rather than at a call site because it spans
+ * two hooks that have to agree: it tallies each finished turn's calls through
+ * `prepareNextTurnWithContext` and, once tripped, offers no tools at all — the
+ * model then has to answer in text.
+ */
+export function createAgentRuntime(opts: AgentRuntimeOptions): AgentRuntime {
+  const loop = createLoopDetector();
+  let turns = 0;
+
+  const agent = new Agent({
+    initialState: {
+      systemPrompt: opts.systemPrompt,
+      model: opts.model,
+      tools: opts.tools,
+      messages: asPi(opts.messages),
+    },
+    streamFn: opts.streamFn,
+    getApiKey: opts.getApiKey,
+    transformContext: composeContext([
+      ...(opts.transforms ?? []),
+      (messages) => injectSystemReminder(messages, currentDateNote(new Date()), { anchor: 'last' }),
+      loop.transform,
+    ]),
+    prepareNextTurnWithContext: async ({ message, context }) => {
+      loop.observe(message);
+      const tools = loop.stopped ? [] : (opts.toolsForNextTurn?.() ?? opts.tools);
+      return { context: { ...context, tools } };
+    },
+    shouldStopAfterTurn: () => ++turns >= MAX_TURNS || (opts.stopAfterTurn?.() ?? false),
+    beforeToolCall: opts.beforeToolCall,
+  });
+
+  return {
+    subscribe: (listener) => {
+      agent.subscribe(listener);
+    },
+    async run(signal) {
+      const stop = () => agent.abort();
+      signal?.addEventListener('abort', stop, { once: true });
+      try {
+        await agent.continue();
+      } finally {
+        signal?.removeEventListener('abort', stop);
+      }
+    },
+  };
+}

--- a/src/main/agent/run-context.ts
+++ b/src/main/agent/run-context.ts
@@ -19,11 +19,12 @@ export type RunContext = {
   providerId?: string;
   modelId?: string;
   /**
-   * Write a transient UI event. Tools speak in stream chunks (`data-*`, `file`)
-   * because that is the vocabulary the renderer's notice router already reads;
-   * the run maps them onto the wire.
+   * Announce something that belongs beside the conversation rather than in it —
+   * a compaction in progress, a subagent's activity. Notices are delivered to
+   * the reader and never stored, so nothing that must survive a reload may go
+   * out this way.
    */
-  emit: (chunk: { type: string; [key: string]: unknown }) => void;
+  notice: (name: string, data: unknown) => void;
   /** Cross-step scratch space; each feature namespaces its own keys. */
   scratch: Map<string, unknown>;
 };

--- a/src/main/agent/run.ts
+++ b/src/main/agent/run.ts
@@ -11,6 +11,7 @@ import { applyResolutions, type ParkedCall, type Resolution } from './pi/approva
 import { type Checkpoint, compactForTurn, withinTurnFold } from './pi/compaction';
 import { type Complete, createCompleter } from './pi/complete';
 import { wireEmitter } from './pi/emitter';
+import { withSettledResults } from './pi/history';
 import { injectContextBlocks, loadContextBlocks } from './pi/injectors';
 import { createRunRecorder, type RunRow } from './pi/recorder';
 import { createAgentRuntime } from './pi/runtime';
@@ -183,7 +184,7 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunResult> {
     emit: opts.emit,
     abortSignal: opts.abortSignal,
   });
-  const messages = settled.length > 0 ? [...compacted, ...settled] : compacted;
+  const messages = withSettledResults(compacted, settled);
 
   /** Calls this turn handed back to the user; they end it and stay open. */
   const parked = new Map<string, ParkedCall>();

--- a/src/main/agent/run.ts
+++ b/src/main/agent/run.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { Agent, type AgentEvent, type StreamFn } from '@earendil-works/pi-agent-core';
-import type { Api, Model, Message as PiMessage } from '@earendil-works/pi-ai';
+import type { Api, Model } from '@earendil-works/pi-ai';
 import type { PermissionMode } from '@shared/permissions';
 import type { AgentSessionEvent, AssistantMessage, Message, ToolCall } from '@shared/protocol';
 import type { Db } from '../db';
@@ -38,6 +38,19 @@ export type RunRow = {
   role: 'assistant' | 'toolResult';
   message: Message;
   metadata?: Record<string, unknown> | null;
+};
+
+/**
+ * How the turn ended, for a caller that isn't watching the event stream. A
+ * model failure is not an exception — pi encodes it as an errored assistant
+ * turn — so a headless caller can only tell success from failure if the run
+ * reports it here.
+ */
+export type RunResult = {
+  status: 'ok' | 'error';
+  error?: string;
+  /** Whether the run stored rows; false when it produced nothing to store. */
+  stored: boolean;
 };
 
 /** What the turn cost, as the ledger records it. */
@@ -130,7 +143,7 @@ const contextSizeOf = (usage: AssistantMessage['usage']): number =>
  *
  * Resolves when the run has settled and every subscriber has finished with it.
  */
-export async function runAgent(opts: RunAgentOptions): Promise<void> {
+export async function runAgent(opts: RunAgentOptions): Promise<RunResult> {
   const soul = await readSoul();
   const startedAt = Date.now();
 
@@ -232,6 +245,7 @@ export async function runAgent(opts: RunAgentOptions): Promise<void> {
   }
   let turns = 0;
   let contextTokens: number | undefined;
+  let failure: string | undefined;
   // What this segment spent. The ledger takes it as-is (a continuation is its
   // own billable call); the stored turn adds it to what the run spent before.
   const totals = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
@@ -245,9 +259,6 @@ export async function runAgent(opts: RunAgentOptions): Promise<void> {
     },
     streamFn: opts.streamFn,
     getApiKey: opts.getApiKey,
-    // Every message in the transcript is an LLM message today; the filter earns
-    // its keep once compaction checkpoints land.
-    convertToLlm: (messages) => messages as PiMessage[],
     /**
      * Everything the model sees beyond the stored transcript, rebuilt for each
      * request and thrown away after it. Order is the contract: the trim runs
@@ -321,6 +332,10 @@ export async function runAgent(opts: RunAgentOptions): Promise<void> {
     if (event.type !== 'message_end') return;
     const message = storedMessage(event.message);
     if (isAssistant(message)) {
+      // A provider failure ends the turn as an errored assistant message rather
+      // than an exception, so this is the only place a headless caller can learn
+      // the run failed.
+      if (message.stopReason === 'error') failure = message.errorMessage ?? 'the model call failed';
       const usage = message.usage;
       totals.input += usage.input;
       totals.output += usage.output;
@@ -361,10 +376,11 @@ export async function runAgent(opts: RunAgentOptions): Promise<void> {
     // pi encodes model failures in the stream; reaching here means the loop
     // itself broke, and the renderer needs to hear about it.
     log.warn(`run failed: ${err}`);
+    failure = err instanceof Error ? err.message : String(err);
     opts.emit({
       type: 'notice',
       name: 'stream-error',
-      payload: { errorText: err instanceof Error ? err.message : String(err) },
+      payload: { errorText: failure },
     });
   } finally {
     opts.abortSignal?.removeEventListener('abort', stopRun);
@@ -405,6 +421,13 @@ export async function runAgent(opts: RunAgentOptions): Promise<void> {
   await recordTurn(opts.workspaceRoot, opts.threadId);
   opts.emit({ type: 'agent_end', willRetry: false });
   opts.onSettled?.();
+
+  // A stop is the user's doing, not a failure — only a real error is reported.
+  return {
+    status: failure && !aborted ? 'error' : 'ok',
+    error: aborted ? undefined : failure,
+    stored: rows.length > 0,
+  };
 }
 
 /**

--- a/src/main/agent/run.ts
+++ b/src/main/agent/run.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from 'node:crypto';
-import { Agent, type AgentEvent, type StreamFn } from '@earendil-works/pi-agent-core';
+import type { StreamFn } from '@earendil-works/pi-agent-core';
 import type { Api, Model } from '@earendil-works/pi-ai';
 import type { PermissionMode } from '@shared/permissions';
-import type { AgentSessionEvent, AssistantMessage, Message, ToolCall } from '@shared/protocol';
+import type { AgentSessionEvent, Message } from '@shared/protocol';
 import type { Db } from '../db';
 import { createLogger } from '../log';
 import { recordTurn } from './memory/state';
@@ -10,19 +10,16 @@ import { type ApprovalContext, approvalGate } from './permissions';
 import { applyResolutions, type ParkedCall, type Resolution } from './pi/approvals';
 import { type Checkpoint, compactForTurn, withinTurnFold } from './pi/compaction';
 import { type Complete, createCompleter } from './pi/complete';
-import { composeContext } from './pi/context';
-import { injectSystemReminder } from './pi/history';
+import { wireEmitter } from './pi/emitter';
 import { injectContextBlocks, loadContextBlocks } from './pi/injectors';
-import { createLoopDetector } from './pi/loop-detection';
-import { projectAgentEvent } from './pi/projector';
+import { createRunRecorder, type RunRow } from './pi/recorder';
+import { createAgentRuntime } from './pi/runtime';
 import { screenshotTrim } from './pi/screenshot-trim';
 import { summarizerFrom } from './pi/summarize';
 import { estimateTokens } from './pi/tokens';
-import { withErrorText } from './pi/tool-result';
 import { scopeToolsToSkill } from './pi/tool-scope';
-import { asPi, storedMessage } from './pi/vocabulary';
 import { readSoul } from './profile/paths';
-import { buildSystemPrompt, currentDateNote } from './prompts';
+import { buildSystemPrompt } from './prompts';
 import type { RunContext } from './run-context';
 import type { Sandbox } from './sandbox/types';
 import { type ActiveSkill, SKILL_SCRATCH_KEY, type Skill } from './skills/types';
@@ -32,13 +29,7 @@ import { preserveTodos } from './tools/builtins/todo';
 
 const log = createLogger('agent');
 
-/** One pi message a run produced, ready to be stored as its own row. */
-export type RunRow = {
-  id: string;
-  role: 'assistant' | 'toolResult';
-  message: Message;
-  metadata?: Record<string, unknown> | null;
-};
+export type { RunRow } from './pi/recorder';
 
 /**
  * How the turn ended, for a caller that isn't watching the event stream. A
@@ -119,27 +110,14 @@ export type RunAgentOptions = {
   onSettled?: () => void;
 };
 
-/** Complex work routinely runs a dozen turns; this is the runaway brake. */
-const MAX_TURNS = 100;
-
 /** What the model is told about a call it will not get a result for this turn. */
 const AWAITING_USER = 'Paused: waiting for the user. The turn ends here.';
 
-const isAssistant = (m: Message): m is AssistantMessage => m.role === 'assistant';
-
-/** What a finished turn actually put in front of the model, cached parts included. */
-const contextSizeOf = (usage: AssistantMessage['usage']): number =>
-  usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
-
 /**
- * The agent loop: pi's `Agent` drives model→tool→model until it stops, and two
- * subscribers fan its events out — one projects them onto the wire, the other
- * accumulates the run's messages and writes them as rows when it settles.
- *
- * Writing at the end rather than per event is deliberate: a run is one stored
- * unit (its rows are replaced together, keeping the group's position when a
- * continuation extends it), and the run-level metadata a reader needs — how
- * long the turn took, what it cost — only exists once the turn is over.
+ * One chat turn. The engine loop, the context it runs on and the two readers of
+ * its events — one projecting onto the wire, one accumulating the rows to store
+ * — are each their own piece; this assembles them and settles the bookkeeping
+ * once the loop is done.
  *
  * Resolves when the run has settled and every subscriber has finished with it.
  */
@@ -159,15 +137,7 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunResult> {
     }),
     providerId: opts.providerId,
     modelId: opts.modelId,
-    // Transient UI channels (an auto-review badge, subagent activity) still
-    // speak in stream chunks; they ride the wire as notices, which is exactly
-    // what the renderer's notice router already expects.
-    emit: (chunk) => {
-      const c = chunk as { type: string };
-      if (!c.type.startsWith('data-')) return;
-      const { type, ...payload } = chunk as { type: string; [key: string]: unknown };
-      opts.emit({ type: 'notice', name: type.slice('data-'.length), payload });
-    },
+    notice: (name, data) => opts.emit({ type: 'notice', name, payload: { data } }),
     scratch: new Map(),
   };
 
@@ -175,7 +145,6 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunResult> {
   // A client-side tool is answered by the user, never executed.
   const clientSide = new Set(tools.filter((t) => t.clientSide).map((t) => t.name));
 
-  const loop = createLoopDetector();
   const blocks = await loadContextBlocks({
     skills: opts.skills,
     workspaceRoot: opts.workspaceRoot,
@@ -192,8 +161,6 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunResult> {
   });
   const summarize = summarizerFrom(complete);
   opts.generateTitle?.({ messages: opts.messages, complete });
-  const announceCompaction = (phase: 'start' | 'done'): void =>
-    ctx.emit({ type: 'data-compaction', data: { phase }, transient: true });
 
   const compacted = opts.persistCheckpoint
     ? await compactForTurn({
@@ -201,7 +168,7 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunResult> {
         summarize,
         contextWindow,
         preservers,
-        emit: announceCompaction,
+        emit: (phase) => ctx.notice('compaction', { phase }),
         persist: opts.persistCheckpoint,
       })
     : opts.messages;
@@ -212,7 +179,7 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunResult> {
   const settled = await applyResolutions({
     resolutions: opts.resolutions ?? [],
     messages: compacted,
-    tools: tools,
+    tools,
     emit: opts.emit,
     abortSignal: opts.abortSignal,
   });
@@ -224,64 +191,52 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunResult> {
     ...opts.permission,
     workspaceRoot: opts.workspaceRoot,
     abortSignal: opts.abortSignal,
-    onReviewed: ({ toolCallId, subject }) =>
-      ctx.emit({ type: 'data-autoReview', data: { toolCallId, subject }, transient: true }),
+    onReviewed: ({ toolCallId, subject }) => ctx.notice('autoReview', { toolCallId, subject }),
   });
 
-  // A run that tripped the loop brake is offered nothing, so the model has to
-  // answer in text; otherwise the active skill decides how wide the set is.
-  const toolsForNextTurn = (): AtriumTool[] =>
-    loop.stopped
-      ? []
-      : scopeToolsToSkill(tools, ctx.scratch.get(SKILL_SCRATCH_KEY) as ActiveSkill | undefined);
-
-  const rows: RunRow[] = [...(opts.resumeRows ?? [])];
   // A continuation extends a turn that already reported itself: it keeps the
   // run's original start, and its cost adds to what the run had already spent.
   const prior = (opts.resumeRows?.[0]?.metadata ?? {}) as Record<string, number | undefined>;
   const openedAt = prior.createdAt ?? startedAt;
-  for (const message of settled) {
-    rows.push({ id: message.toolCallId, role: 'toolResult', message });
-  }
-  let turns = 0;
-  let contextTokens: number | undefined;
-  let failure: string | undefined;
-  // What this segment spent. The ledger takes it as-is (a continuation is its
-  // own billable call); the stored turn adds it to what the run spent before.
-  const totals = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+  const recorder = createRunRecorder({
+    runId: opts.runId,
+    parked,
+    seed: [
+      ...(opts.resumeRows ?? []),
+      ...settled.map((message) => ({
+        id: message.toolCallId,
+        role: 'toolResult' as const,
+        message,
+      })),
+    ],
+  });
 
-  const agent = new Agent({
-    initialState: {
-      systemPrompt: ctx.system,
-      model: opts.piModel,
-      tools,
-      messages: asPi(messages),
-    },
+  const runtime = createAgentRuntime({
+    systemPrompt: ctx.system,
+    model: opts.piModel,
     streamFn: opts.streamFn,
     getApiKey: opts.getApiKey,
+    messages,
+    tools,
     /**
      * Everything the model sees beyond the stored transcript, rebuilt for each
      * request and thrown away after it. Order is the contract: the trim runs
      * first so the fold measures the smaller view, and the fold before the
-     * standing blocks so it can never summarize them away; the blocks then
-     * land on the first user turn (so they ride inside the cached prefix); the
-     * date lands on the current one before any notice can claim that spot; and
-     * the loop notice goes last, closest to what the model is about to answer.
+     * standing blocks so it can never summarize them away; the blocks then land
+     * on the first user turn, so they ride inside the cached prefix.
      */
-    transformContext: composeContext([
+    transforms: [
       screenshotTrim(opts.workspaceRoot),
       withinTurnFold({ summarize, contextWindow, overheadTokens, preservers }),
       injectContextBlocks(blocks),
-      (messages) => injectSystemReminder(messages, currentDateNote(new Date()), { anchor: 'last' }),
-      loop.transform,
-    ]),
-    prepareNextTurnWithContext: async ({ message, context }) => {
-      loop.observe(message);
-      return { context: { ...context, tools: toolsForNextTurn() } };
-    },
+    ],
+    // The active skill decides how wide the offered set is; recomputed from the
+    // full set each turn so a narrowing can never compound.
+    toolsForNextTurn: () =>
+      scopeToolsToSkill(tools, ctx.scratch.get(SKILL_SCRATCH_KEY) as ActiveSkill | undefined),
     // A parked call ends the turn: the rest of its batch still runs, but nothing
     // new is asked of the model until the user has answered.
-    shouldStopAfterTurn: () => ++turns >= MAX_TURNS || parked.size > 0,
+    stopAfterTurn: () => parked.size > 0,
     beforeToolCall: async ({ toolCall, args }) => {
       const park = (approvalId?: string) => {
         parked.set(toolCall.id, { toolCallId: toolCall.id, toolName: toolCall.name, approvalId });
@@ -296,97 +251,24 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunResult> {
     },
   });
 
-  // pi owns the run's abort signal, so the turn's signal is forwarded to it.
-  const stopRun = () => agent.abort();
-  opts.abortSignal?.addEventListener('abort', stopRun, { once: true });
-
-  agent.subscribe((event: AgentEvent) => {
-    // The run emits its own agent_end once its bookkeeping is done, so that the
-    // wire's promise — agent_end is the last event — stays literally true.
-    if (event.type === 'agent_end') return;
-    const projected = projectAgentEvent(event, opts.runId);
-    if (!projected) return;
-    // pi announces every appended message; only assistant turns belong on the
-    // wire — tool results arrive as tool_execution_end, and the user's message
-    // is what started the run.
-    if (
-      (projected.type === 'message_start' || projected.type === 'message_end') &&
-      projected.message.role !== 'assistant'
-    ) {
-      return;
-    }
-    if (projected.type === 'tool_execution_end') {
-      // A parked call produced no result — the card is showing the ask, and a
-      // refusal frame would replace it with an error the user never caused.
-      if (parked.has(projected.toolCallId)) return;
-      projected.result.details = withErrorText(
-        projected.result.details,
-        projected.result.content,
-        projected.isError,
-      );
-    }
-    opts.emit(projected);
-  });
-
-  agent.subscribe((event: AgentEvent) => {
-    if (event.type !== 'message_end') return;
-    const message = storedMessage(event.message);
-    if (isAssistant(message)) {
-      // A provider failure ends the turn as an errored assistant message rather
-      // than an exception, so this is the only place a headless caller can learn
-      // the run failed.
-      if (message.stopReason === 'error') failure = message.errorMessage ?? 'the model call failed';
-      const usage = message.usage;
-      totals.input += usage.input;
-      totals.output += usage.output;
-      totals.cacheRead += usage.cacheRead;
-      totals.cacheWrite += usage.cacheWrite;
-      totals.total += usage.totalTokens;
-      // The prompt at turn end — the honest base for compaction's threshold,
-      // where the cumulative figure would count a tool loop many times over.
-      // Not `input + output`: a cached prompt bills only its uncached part to
-      // `input`, so that pair reads as a fraction of what was actually sent.
-      contextTokens = contextSizeOf(usage);
-      // A turn that produced nothing (the provider errored before its first
-      // block) is not stored: an empty content list is rejected outright when
-      // it comes back as history, which would wedge the thread for good.
-      if (message.content.length > 0) {
-        rows.push({
-          id: `${opts.runId}:${rows.filter((r) => r.role === 'assistant').length}`,
-          role: 'assistant',
-          message,
-        });
-      }
-      return;
-    }
-    if (message.role === 'toolResult') {
-      // Same for storage: a parked call is stored as still open, so a reload
-      // shows the ask again and the decision can still land on it.
-      if (parked.has(message.toolCallId)) return;
-      message.details = withErrorText(message.details, message.content, message.isError);
-      rows.push({ id: message.toolCallId, role: 'toolResult', message });
-    }
-  });
+  runtime.subscribe(wireEmitter({ runId: opts.runId, parked, emit: opts.emit }));
+  runtime.subscribe(recorder.observe);
 
   opts.emit({ type: 'notice', name: 'message-metadata', payload: { createdAt: openedAt } });
 
+  let loopError: string | undefined;
   try {
-    await agent.continue();
+    await runtime.run(opts.abortSignal);
   } catch (err) {
     // pi encodes model failures in the stream; reaching here means the loop
     // itself broke, and the renderer needs to hear about it.
     log.warn(`run failed: ${err}`);
-    failure = err instanceof Error ? err.message : String(err);
-    opts.emit({
-      type: 'notice',
-      name: 'stream-error',
-      payload: { errorText: failure },
-    });
-  } finally {
-    opts.abortSignal?.removeEventListener('abort', stopRun);
+    loopError = err instanceof Error ? err.message : String(err);
+    opts.emit({ type: 'notice', name: 'stream-error', payload: { errorText: loopError } });
   }
 
   const aborted = opts.abortSignal?.aborted ?? false;
+  const totals = recorder.totals;
   const metadata = {
     createdAt: openedAt,
     durationMs: Date.now() - openedAt,
@@ -397,14 +279,12 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunResult> {
     cacheReadTokens: (prior.cacheReadTokens ?? 0) + totals.cacheRead,
     cacheCreationTokens: (prior.cacheCreationTokens ?? 0) + totals.cacheWrite,
     totalTokens: (prior.totalTokens ?? 0) + totals.total,
-    contextTokens: contextTokens ?? prior.contextTokens,
+    contextTokens: recorder.contextTokens ?? prior.contextTokens,
   };
   opts.emit({ type: 'notice', name: 'message-metadata', payload: metadata });
 
+  const rows = recorder.finalize(metadata);
   if (rows.length > 0) {
-    stampParkedCalls(rows, parked);
-    sealUnansweredCalls(rows, parked);
-    rows[0].metadata = { ...rows[0].metadata, ...metadata };
     opts.persist(rows, { markRead: aborted });
     opts.recordUsage?.({
       messageId: opts.runId,
@@ -423,74 +303,10 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunResult> {
   opts.onSettled?.();
 
   // A stop is the user's doing, not a failure — only a real error is reported.
+  const failure = loopError ?? recorder.failure;
   return {
     status: failure && !aborted ? 'error' : 'ok',
     error: aborted ? undefined : failure,
     stored: rows.length > 0,
   };
-}
-
-/**
- * Record each parked call's pending state on the turn that made it. The row
- * vocabulary has no slot for "waiting on the user" — a call is open or it has a
- * result — so the UI state rides in the row's metadata, which is where every
- * other tool-state extra already lives.
- */
-function stampParkedCalls(rows: RunRow[], parked: Map<string, ParkedCall>): void {
-  if (parked.size === 0) return;
-  for (const row of rows) {
-    if (row.message.role !== 'assistant') continue;
-    const states: Record<string, unknown> = {};
-    for (const content of row.message.content) {
-      if (content.type !== 'toolCall') continue;
-      const call = parked.get((content as ToolCall).id);
-      if (!call) continue;
-      states[call.toolCallId] = call.approvalId
-        ? { state: 'approval-requested', approval: { id: call.approvalId } }
-        : { state: 'input-available' };
-    }
-    if (Object.keys(states).length === 0) continue;
-    const existing = (row.metadata?.toolStates ?? {}) as Record<string, unknown>;
-    row.metadata = { ...row.metadata, toolStates: { ...existing, ...states } };
-  }
-}
-
-const SEAL_ERROR = 'Stopped before the tool returned.';
-
-/**
- * Give every tool call a result row. A stopped turn leaves its in-flight call
- * unanswered, and both the provider (which rejects an unpaired tool call in the
- * history) and the card (which would sit spinning forever) need it closed.
- */
-function sealUnansweredCalls(rows: RunRow[], parked: Map<string, ParkedCall>): void {
-  const answered = new Set([
-    ...parked.keys(),
-    ...rows.flatMap((row) => (row.role === 'toolResult' ? [row.id] : [])),
-  ]);
-  const sealed: RunRow[] = [];
-  for (const row of rows) {
-    sealed.push(row);
-    if (row.message.role !== 'assistant') continue;
-    for (const content of row.message.content) {
-      if (content.type !== 'toolCall') continue;
-      const call = content as ToolCall;
-      if (answered.has(call.id)) continue;
-      answered.add(call.id);
-      sealed.push({
-        id: call.id,
-        role: 'toolResult',
-        message: {
-          role: 'toolResult',
-          toolCallId: call.id,
-          toolName: call.name,
-          content: [{ type: 'text', text: SEAL_ERROR }],
-          details: { errorText: SEAL_ERROR },
-          isError: true,
-          timestamp: row.message.timestamp,
-        },
-      });
-    }
-  }
-  rows.length = 0;
-  rows.push(...sealed);
 }

--- a/src/main/agent/scheduled/manager.test.ts
+++ b/src/main/agent/scheduled/manager.test.ts
@@ -48,13 +48,18 @@ function makeDb(): Db {
 
 const START = 1_700_000_000_000;
 
+const unreachable = (): never => {
+  throw new Error('the scheduled tests never start a real run');
+};
+
 function setup(runner?: (task: ScheduledTask) => Promise<ScheduledRunResult>) {
   const db = makeDb();
   const nowRef = { v: START };
   const mgr = new ScheduledTaskManager();
   mgr.init({
     db,
-    endpoint: { port: 0, token: 't' },
+    // Every test injects `run`, so the real runner is never reached.
+    runner: { start: () => unreachable(), dispose: () => {} },
     defaultModel: () => ({ providerId: 'p', modelId: 'm' }),
     now: () => nowRef.v,
     run: runner ?? (async () => ({ status: 'ok', messageId: 'a1' })),

--- a/src/main/agent/scheduled/manager.ts
+++ b/src/main/agent/scheduled/manager.ts
@@ -7,8 +7,9 @@ import type { Db } from '../../db';
 import type { ScheduledTask, ScheduledTaskRun } from '../../db/schema';
 import { scheduledTaskRuns, scheduledTasks, threads } from '../../db/schema';
 import { createLogger } from '../../log';
+import type { Runner } from '../../server/runner';
 import { computeNextRun } from './cron';
-import { type RunEndpoint, runScheduledTask, type ScheduledRunResult } from './run';
+import { runScheduledTask, type ScheduledRunResult } from './run';
 
 const log = createLogger('scheduled');
 
@@ -17,7 +18,8 @@ const FAILURE_THRESHOLD = 5;
 
 export type ScheduledManagerDeps = {
   db: Db;
-  endpoint: RunEndpoint;
+  /** The shared run composition root; scheduled turns run on the same one chat does. */
+  runner: Runner;
   defaultModel: () => SelectedModel | null;
   /** Fired after each run settles, for the notification layer. */
   onComplete?: (task: ScheduledTask, run: ScheduledTaskRun) => void;
@@ -64,7 +66,7 @@ export type ScheduledTaskView = ScheduledTask & {
  * in-memory croner jobs never drift from the DB. Every mutation (from the tRPC
  * router or an agent tool) goes through here, and each firing appends a turn to
  * the task's bound thread. Construct once as `scheduledManager`, `init()` it
- * with the app's db + chat endpoint at boot, then `start()`.
+ * with the app's db + runner at boot, then `start()`.
  */
 export class ScheduledTaskManager {
   private deps!: ScheduledManagerDeps;
@@ -85,11 +87,11 @@ export class ScheduledTaskManager {
     return this.deps.now?.() ?? Date.now();
   }
 
-  private runner(task: ScheduledTask): Promise<ScheduledRunResult> {
+  private runTask(task: ScheduledTask): Promise<ScheduledRunResult> {
     return this.deps.run
       ? this.deps.run(task)
       : runScheduledTask(
-          { db: this.db, endpoint: this.deps.endpoint, defaultModel: this.deps.defaultModel },
+          { db: this.db, runner: this.deps.runner, defaultModel: this.deps.defaultModel },
           task,
         );
   }
@@ -389,7 +391,7 @@ export class ScheduledTaskManager {
 
       let result: ScheduledRunResult;
       try {
-        result = await this.runner(task);
+        result = await this.runTask(task);
       } catch (err) {
         log.error(`scheduled task ${id} threw`, err);
         result = { status: 'error', error: String(err) };

--- a/src/main/agent/scheduled/run.ts
+++ b/src/main/agent/scheduled/run.ts
@@ -4,12 +4,11 @@ import type { SelectedModel } from '@shared/settings';
 import { and, desc, eq, isNotNull } from 'drizzle-orm';
 import type { Db } from '../../db';
 import type { ScheduledTask } from '../../db/schema';
-import { messages, scheduledTaskRuns } from '../../db/schema';
+import { scheduledTaskRuns } from '../../db/schema';
 import { createLogger } from '../../log';
+import type { Runner } from '../../server/runner';
 
 const log = createLogger('scheduled');
-
-export type RunEndpoint = { port: number; token: string };
 
 export type ScheduledRunResult = {
   status: 'ok' | 'error';
@@ -47,33 +46,14 @@ function lastCompletedRunAt(db: Db, taskId: string): Date | undefined {
     .get()?.startedAt;
 }
 
-/** Run-level id of the newest assistant message in a thread, or undefined. */
-function latestAssistantId(db: Db, threadId: string): string | undefined {
-  const row = db
-    .select({ id: messages.id, runId: messages.runId })
-    .from(messages)
-    .where(and(eq(messages.threadId, threadId), eq(messages.role, 'assistant')))
-    .orderBy(desc(messages.createdAt))
-    .limit(1)
-    .get();
-  return row?.runId ?? row?.id;
-}
-
 /**
- * Fire one scheduled task headlessly by driving the same localhost chat pipeline
- * the renderer uses: append the task prompt as a user turn to the task's bound
- * thread, then drain the response to completion. The run is decoupled from any
- * client (resumable.ts owns its lifetime), so draining here just tells us when
- * the turn finished — the messages are already persisted by the pipeline.
- *
- * The turn's own errors surface as an in-stream `error` chunk (onError), not an
- * HTTP status, so we scan the streamed bytes for one to report an accurate
- * ok/error — that's what drives the task's consecutive-failure auto-pause. The
- * produced assistant message is identified by diffing the thread's latest
- * assistant id across the run, so a failed run mis-attributes nothing.
+ * Fire one scheduled task headlessly: append the task prompt as a user turn to
+ * the task's bound thread and run it on the same runner the chat endpoint uses.
+ * The run reports its own outcome, which is what drives the task's
+ * consecutive-failure auto-pause; the messages are persisted by the run itself.
  */
 export async function runScheduledTask(
-  deps: { db: Db; endpoint: RunEndpoint; defaultModel: () => SelectedModel | null },
+  deps: { db: Db; runner: Runner; defaultModel: () => SelectedModel | null },
   task: ScheduledTask,
 ): Promise<ScheduledRunResult> {
   if (!task.threadId) return { status: 'error', error: 'Scheduled task has no bound thread.' };
@@ -85,7 +65,6 @@ export async function runScheduledTask(
     return { status: 'error', error: 'No model configured for this scheduled task.' };
   }
 
-  const priorAssistant = latestAssistantId(deps.db, task.threadId);
   // A Codex-style key:value preamble frames the turn as an automation run. The
   // Instruction line is our own: each fire appends to the bound thread, so the
   // model sees prior runs and would otherwise reply "already done" and skip.
@@ -105,51 +84,22 @@ export async function runScheduledTask(
 
   const release = blockSuspension();
   try {
-    let res: Response;
-    try {
-      res = await fetch(`http://127.0.0.1:${deps.endpoint.port}/api/chat`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'x-atrium-token': deps.endpoint.token },
-        body: JSON.stringify({
-          threadId: task.threadId,
-          providerId: model.providerId,
-          modelId: model.modelId,
-          message,
-          permissionMode: task.permissionMode,
-        }),
-      });
-    } catch (err) {
-      log.error(`fetch failed for task ${task.id}`, err);
-      return { status: 'error', error: String(err) };
+    const outcome = await deps.runner.start({
+      threadId: task.threadId,
+      providerId: model.providerId,
+      modelId: model.modelId,
+      permissionMode: task.permissionMode,
+      userMessage: message,
+    }).settled;
+    if (outcome.status === 'error') {
+      log.error(`task ${task.id} run failed: ${outcome.error}`);
     }
-
-    if (!res.ok || !res.body) {
-      const body = await res.text().catch(() => '');
-      return { status: 'error', error: `chat endpoint ${res.status}: ${body}`.trim() };
-    }
-
-    // Drain the pi event SSE to EOF; the turn is done when the stream closes.
-    // Scan the decoded bytes for a stream-error notice so a model/tool failure
-    // counts as a failed run rather than a silent success.
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder();
-    let streamError: string | undefined;
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (streamError) continue;
-      const text = decoder.decode(value, { stream: true });
-      const match = text.match(/"name":"stream-error".*?"errorText":"((?:[^"\\]|\\.)*)"/);
-      if (match) streamError = match[1] ? JSON.parse(`"${match[1]}"`) : 'The scheduled run failed.';
-    }
-
-    const after = latestAssistantId(deps.db, task.threadId);
-    const messageId = after && after !== priorAssistant ? after : undefined;
-    if (streamError) {
-      log.error(`task ${task.id} run failed: ${streamError}`);
-      return { status: 'error', error: streamError, messageId };
-    }
-    return { status: 'ok', messageId };
+    return { status: outcome.status, error: outcome.error, messageId: outcome.messageId };
+  } catch (err) {
+    // A request the runner refuses outright (an unresolvable model) throws
+    // before the run ever starts.
+    log.error(`task ${task.id} could not start`, err);
+    return { status: 'error', error: err instanceof Error ? err.message : String(err) };
   } finally {
     release();
   }

--- a/src/main/agent/subagent/run.test.ts
+++ b/src/main/agent/subagent/run.test.ts
@@ -80,7 +80,7 @@ function parentCtx(over: Partial<RunContext> = {}): RunContext {
     sandbox: {} as Sandbox,
     workspaceRoot: '/ws',
     system: 'PARENT SYSTEM PROMPT',
-    emit: () => {},
+    notice: () => {},
     scratch: new Map(),
     ...over,
   } as RunContext;
@@ -139,7 +139,7 @@ test('runs the full loop but returns only the final text, never tool output', as
 test('bubbles its activity up to the parent, minus the plan tool', async () => {
   const emitted: unknown[] = [];
   await runSubagent({
-    parent: parentCtx({ emit: (chunk) => emitted.push(chunk) }),
+    parent: parentCtx({ notice: (_name, data) => emitted.push(data) }),
     engine: engineWith(
       scripted([
         reply(
@@ -158,12 +158,12 @@ test('bubbles its activity up to the parent, minus the plan tool', async () => {
     subagentId: 's3',
   });
 
-  const phases = emitted.map((c) => (c as { data: { phase: string } }).data.phase);
+  const phases = emitted.map((d) => (d as { phase: string }).phase);
   expect(phases[0]).toBe('start');
   expect(phases.at(-1)).toBe('done');
-  const step = emitted
-    .map((c) => (c as { data: { phase: string; tools?: { name: string }[] } }).data)
-    .find((d) => d.phase === 'step');
+  const step = (emitted as { phase: string; tools?: { name: string }[] }[]).find(
+    (d) => d.phase === 'step',
+  );
   expect(step?.tools?.map((t) => t.name)).toEqual(['echo']);
 });
 

--- a/src/main/agent/subagent/run.ts
+++ b/src/main/agent/subagent/run.ts
@@ -1,25 +1,21 @@
-import { Agent, type StreamFn } from '@earendil-works/pi-agent-core';
-import type { Api, Model, Message as PiMessage } from '@earendil-works/pi-ai';
+import type { StreamFn } from '@earendil-works/pi-agent-core';
+import type { Api, Model } from '@earendil-works/pi-ai';
 import type { AssistantMessage, Message, TextContent, Usage } from '@shared/protocol';
 import type { ToolName } from '@shared/tools';
 import { recordUsage } from '../../db/usage';
 import { createLogger } from '../../log';
 import type { ModelPricing } from '../models/types';
 import { withinTurnFold } from '../pi/compaction';
-import { composeContext } from '../pi/context';
-import { injectSystemReminder } from '../pi/history';
-import { createLoopDetector } from '../pi/loop-detection';
+import { createAgentRuntime } from '../pi/runtime';
 import { createSummarizer } from '../pi/summarize';
-import { asPi, storedMessage } from '../pi/vocabulary';
-import { currentDateNote, workspaceGuidance } from '../prompts';
+import { storedMessage } from '../pi/vocabulary';
+import { workspaceGuidance } from '../prompts';
 import type { RunContext } from '../run-context';
 import type { AtriumTool } from '../tools';
 import { preserveTodos } from '../tools/builtins/todo';
 import type { SubagentDef } from './defs';
 
 const log = createLogger('subagent');
-
-const SUBAGENT_MAX_TURNS = 100;
 
 /** What a nested loop needs to reach a provider — the parent's, by default. */
 export type SubagentEngine = {
@@ -115,30 +111,24 @@ export async function runSubagent(opts: RunSubagentOptions): Promise<SubagentRes
   ];
 
   const emit = (data: Record<string, unknown>): void =>
-    parent.emit({ type: 'data-subagent', data: { id: opts.subagentId, ...data }, transient: true });
+    parent.notice('subagent', { id: opts.subagentId, ...data });
 
-  const loop = createLoopDetector();
-  let turns = 0;
-
-  const child = new Agent({
-    initialState: { systemPrompt, model, tools: opts.tools, messages: asPi(messages) },
+  const child = createAgentRuntime({
+    systemPrompt,
+    model,
     streamFn: opts.engine.streamFn,
     getApiKey: opts.engine.getApiKey,
-    convertToLlm: (m) => m as PiMessage[],
-    transformContext: composeContext([
+    messages,
+    tools: opts.tools,
+    // The child can run many turns and overflow its own window, but it has no
+    // persisted history to check point against — only the within-turn fold.
+    transforms: [
       withinTurnFold({
         summarize: createSummarizer({ ...opts.engine, model }),
         contextWindow: model.contextWindow,
         preservers: [preserveTodos],
       }),
-      (m) => injectSystemReminder(m, currentDateNote(new Date()), { anchor: 'last' }),
-      loop.transform,
-    ]),
-    prepareNextTurnWithContext: async ({ message, context }) => {
-      loop.observe(message);
-      return { context: { ...context, tools: loop.stopped ? [] : opts.tools } };
-    },
-    shouldStopAfterTurn: () => ++turns >= SUBAGENT_MAX_TURNS,
+    ],
   });
 
   const usage = zeroUsage();
@@ -168,17 +158,12 @@ export async function runSubagent(opts: RunSubagentOptions): Promise<SubagentRes
     if (tools.length > 0) emit({ phase: 'step', tools });
   });
 
-  const stop = () => child.abort();
-  opts.abortSignal?.addEventListener('abort', stop, { once: true });
-
   emit({ phase: 'start' });
   try {
-    await child.continue();
+    await child.run(opts.abortSignal);
   } catch (err) {
     emit({ phase: 'done', status: 'failed' });
     throw err;
-  } finally {
-    opts.abortSignal?.removeEventListener('abort', stop);
   }
 
   // Subagent calls are separate model calls, invisible to the parent turn's

--- a/src/main/agent/tools/builtins/task.test.ts
+++ b/src/main/agent/tools/builtins/task.test.ts
@@ -58,7 +58,7 @@ function ctx(db: Db): RunContext {
     sandbox: {} as Sandbox,
     workspaceRoot: '/ws',
     system: 's',
-    emit: () => {},
+    notice: () => {},
     scratch: new Map(),
   };
 }

--- a/src/main/agent/tools/context.ts
+++ b/src/main/agent/tools/context.ts
@@ -1,9 +1,6 @@
 import type { StreamFn } from '@earendil-works/pi-agent-core';
 import type { Api, Model } from '@earendil-works/pi-ai';
-import type { PermissionMode } from '@shared/permissions';
-import type { TrustRule } from '@shared/permissions/rules';
 import type { ComputerUseHelper } from '../../computer-use';
-import type { Complete } from '../pi/complete';
 import type { RunContext } from '../run-context';
 import type { BackgroundShells } from '../sandbox/background-shells';
 import type { Sandbox } from '../sandbox/types';
@@ -46,12 +43,4 @@ export type ToolCtx = {
    *  emitting image parts lets openai-compatible stringify base64 into the
    *  prompt. */
   supportsImageToolResults?: boolean;
-  permission?: {
-    mode: PermissionMode;
-    rules?: TrustRule[];
-    /** Reviewer for auto-review mode; absent → auto-review falls back to prompting. */
-    review?: Complete;
-    /** The turn's abort signal, so a stopped turn also cancels an in-flight review. */
-    abortSignal?: AbortSignal;
-  };
 };

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,8 +29,9 @@ import {
   useCredentialStore,
 } from './providers/pi-model';
 import { firstEnabledModel } from './providers/resolve';
-import { type ChatEndpoint, startHttpServer } from './server/http';
+import { startHttpServer } from './server/http';
 import { getRunningThreadIds } from './server/resumable';
+import { createRunner, type Runner } from './server/runner';
 import { getSettings, openSettings } from './settings/conf';
 import { attachWindowStatePersistence, getInitialWindowState } from './settings/window-state';
 import { loadShellEnv } from './shell-path';
@@ -116,8 +117,8 @@ function createWindow(): BrowserWindow {
 }
 
 // Held at module scope so before-quit can dispose it (kill background shells) —
-// assigned once the server is up inside whenReady.
-let serverEndpoint: ChatEndpoint | undefined;
+// assigned once the runner exists inside whenReady.
+let runner: Runner | undefined;
 
 app.whenReady().then(async () => {
   electronApp.setAppUserModelId('com.atrium.app');
@@ -138,11 +139,15 @@ app.whenReady().then(async () => {
   const projectlessRoot = join(homedir(), 'Documents', 'Atrium');
   mkdirSync(projectlessRoot, { recursive: true });
 
+  // One composition root for every turn — the chat endpoint and the scheduler
+  // are both callers of it.
+  const runs = createRunner({ db, projectlessRoot });
+  runner = runs;
+
   // Bring the chat server up first — it's a fast port bind — so the IPC handler
   // attaches before the window paints and the renderer's first tRPC calls never
   // race a missing handler.
-  const chatEndpoint = await startHttpServer({ db, token: randomUUID(), projectlessRoot });
-  serverEndpoint = chatEndpoint;
+  const chatEndpoint = await startHttpServer({ db, token: randomUUID(), runner: runs });
 
   app.on('browser-window-created', (_, window) => {
     optimizer.watchWindowShortcuts(window);
@@ -239,7 +244,7 @@ app.whenReady().then(async () => {
   const startScheduler = (): void => {
     startScheduledTasks({
       db,
-      endpoint: { port: chatEndpoint.port, token: chatEndpoint.token },
+      runner: runs,
       runningThreadIds: getRunningThreadIds,
       defaultModel: () => {
         // The renderer only persists general.defaultModel on an explicit pick, so
@@ -285,7 +290,7 @@ app.on('window-all-closed', () => {
 
 app.on('before-quit', () => {
   isQuitting = true;
-  serverEndpoint?.dispose();
+  runner?.dispose();
   scheduledManager.dispose();
   void mcpManager.dispose();
   updaterManager.dispose();

--- a/src/main/server/http.ts
+++ b/src/main/server/http.ts
@@ -6,19 +6,14 @@ import { cors } from 'hono/cors';
 import type { Resolution } from '../agent/pi/approvals';
 import { toolCallsById } from '../agent/pi/approvals';
 import { foldToCheckpoint } from '../agent/pi/compaction';
+import type { RunRow } from '../agent/pi/recorder';
 import { createSummarizer } from '../agent/pi/summarize';
 import { preserveActiveSkill } from '../agent/tools/builtins/skill';
 import { preserveTodos } from '../agent/tools/builtins/todo';
 import type { Db } from '../db';
 import { createLogger } from '../log';
 import { makeGetApiKey, piStreamFn, resolvePiModel } from '../providers/pi-model';
-import {
-  loadRunRows,
-  loadThreadHistory,
-  persistCheckpoint,
-  type RunRow,
-  resolveToolOutput,
-} from './persist';
+import { loadRunRows, loadThreadHistory, persistCheckpoint, resolveToolOutput } from './persist';
 import { subscribePiEvents } from './pi-events';
 import { abortThreadRun, isThreadRunning } from './resumable';
 import type { Runner } from './runner';

--- a/src/main/server/http.ts
+++ b/src/main/server/http.ts
@@ -1,47 +1,29 @@
-import { randomUUID } from 'node:crypto';
 import { serve } from '@hono/node-server';
 import type { AtriumUIMessage } from '@shared/chat';
-import { DEFAULT_PERMISSION_MODE, type PermissionMode } from '@shared/permissions';
+import type { PermissionMode } from '@shared/permissions';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
-import { mcpManager } from '../agent/mcp/manager';
-import { buildMcpTools } from '../agent/mcp/tool-adapter';
-
-import { modelPricing } from '../agent/models/catalog';
 import type { Resolution } from '../agent/pi/approvals';
 import { toolCallsById } from '../agent/pi/approvals';
 import { foldToCheckpoint } from '../agent/pi/compaction';
-import { type Complete, createCompleter } from '../agent/pi/complete';
 import { createSummarizer } from '../agent/pi/summarize';
-import { generateThreadTitle } from '../agent/pi/title';
-import { runAgent } from '../agent/run';
-import { BackgroundShells, LocalSandbox } from '../agent/sandbox';
-import { getSkills } from '../agent/skills/registry';
-import { getTools } from '../agent/tools';
 import { preserveActiveSkill } from '../agent/tools/builtins/skill';
 import { preserveTodos } from '../agent/tools/builtins/todo';
-import { getComputerUseHelper } from '../computer-use';
 import type { Db } from '../db';
-import { recordUsage } from '../db/usage';
 import { createLogger } from '../log';
 import { makeGetApiKey, piStreamFn, resolvePiModel } from '../providers/pi-model';
-import { supportsImageToolResults } from '../providers/resolve';
-import { getSettings } from '../settings/conf';
 import {
   loadRunRows,
   loadThreadHistory,
   persistCheckpoint,
-  persistMessage,
-  persistRun,
   type RunRow,
-  resolveThreadWorkspace,
   resolveToolOutput,
-  setThreadTitle,
 } from './persist';
 import { subscribePiEvents } from './pi-events';
-import { abortThreadRun, isThreadRunning, startThreadRun } from './resumable';
+import { abortThreadRun, isThreadRunning } from './resumable';
+import type { Runner } from './runner';
 
-export type ChatEndpoint = { port: number; token: string; dispose: () => void };
+export type ChatEndpoint = { port: number; token: string };
 
 const PI_SSE_HEADERS = {
   'Content-Type': 'text/event-stream',
@@ -68,37 +50,7 @@ type ChatBody = {
   permissionMode?: PermissionMode;
 };
 
-/**
- * Localhost HTTP server for AI streaming. Lives alongside electron-trpc:
- * tRPC handles CRUD, this handles the chat stream — a long-lived HTTP response
- * the renderer reads as SSE. Bound to 127.0.0.1 on a random free port; a per-launch token gates /api/* so other local processes
- * can't drive the user's model credits.
- */
 const log = createLogger('chat');
-
-/**
- * Resolve the auto-review reviewer model. Prefers the dedicated setting; when
- * unset, falls back to this turn's chat model so auto-review works out of the
- * box. Returns undefined (→ auto-review prompts) when nothing resolves — a
- * removed model.
- */
-function resolveReviewer(
-  db: Db,
-  fallback: { providerId: string; modelId: string },
-): Complete | undefined {
-  const configured = getSettings('permissions.reviewerModel');
-  const picked = configured ?? fallback;
-  try {
-    const model = resolvePiModel(db, picked.providerId, picked.modelId);
-    log.info(
-      `reviewer = ${picked.providerId}/${picked.modelId}${configured ? '' : ' (inherited chat model)'}`,
-    );
-    return createCompleter({ model, streamFn: piStreamFn, getApiKey: makeGetApiKey(db) });
-  } catch (err) {
-    log.info(`reviewer unresolved (${picked.providerId}/${picked.modelId}) → prompts: ${err}`);
-    return undefined;
-  }
-}
 
 /**
  * The decisions a resumed message carries for the calls its run left open. The
@@ -132,15 +84,22 @@ function resolutionsFor(message: AtriumUIMessage, resumeRows: RunRow[]): Resolut
   return out;
 }
 
+/**
+ * Localhost HTTP server for AI streaming. Lives alongside electron-trpc: tRPC
+ * handles CRUD, this handles the chat stream — a long-lived HTTP response the
+ * renderer reads as SSE. Bound to 127.0.0.1 on a random free port; a per-launch
+ * token gates /api/* so other local processes can't drive the user's model
+ * credits.
+ *
+ * This layer only translates: it turns a request into a run request and a run's
+ * event log into an SSE body. How a run is assembled belongs to the runner.
+ */
 export function startHttpServer(deps: {
   db: Db;
   token: string;
-  projectlessRoot: string;
+  runner: Runner;
 }): Promise<ChatEndpoint> {
   const app = new Hono();
-  // Long-running shells (dev servers, watchers) outlive a request, so the
-  // registry is a single instance held for the server's lifetime, not per-call.
-  const bgShells = new BackgroundShells();
   // Renderer is a different origin (localhost:5173 in dev, file:// in prod);
   // CORS must run before auth so the credential-less preflight isn't 401'd.
   app.use(
@@ -161,126 +120,24 @@ export function startHttpServer(deps: {
     const { threadId, providerId, modelId, message, permissionMode } = await c.req.json<ChatBody>();
     if (!threadId) return c.text('threadId required', 400);
 
-    // Persist the just-sent user message; the turn's history is rebuilt from
-    // the DB below, which is the source of truth, not the client. An assistant
-    // message arrives only when a client-side tool (ask_clarification) was just
-    // answered and the chat auto-resumed: the stored call is overwritten so
-    // history carries the answer the model is about to continue from.
-    if (message.role === 'user') persistMessage(deps.db, threadId, message);
+    // An assistant message arrives only when a client-side tool (a clarification
+    // or an approval) was just answered and the chat auto-resumed: the run it
+    // belongs to is continued, and the message is read for the user's decisions
+    // rather than stored.
+    const resumeRunId = message.role === 'assistant' ? message.id : undefined;
+    const resolutions = resumeRunId
+      ? resolutionsFor(message, loadRunRows(deps.db, resumeRunId))
+      : [];
 
-    // Resolve the thread's workspace per request: its project's directory, or
-    // the projectless fallback. Drives the sandbox and the tools below.
-    const workspaceRoot = resolveThreadWorkspace(deps.db, threadId, deps.projectlessRoot);
-
-    const abort = new AbortController();
-
-    const sandbox = new LocalSandbox(workspaceRoot);
-    const skills = getSkills();
-    const mode = permissionMode ?? DEFAULT_PERMISSION_MODE;
-    const supportsImages = supportsImageToolResults(providerId, modelId);
-    const computerUse =
-      process.platform === 'darwin' && getSettings('computerUse.enabled')
-        ? getComputerUseHelper()
-        : undefined;
-    // A continuation resumes the run the client is answering (its assistant
-    // message id), so the model's next turns extend that same stored run
-    // instead of opening a second one.
-    const runId = message.role === 'assistant' ? message.id : randomUUID();
-    const piModel = resolvePiModel(deps.db, providerId, modelId);
-    // A continuation answers calls an earlier turn parked. What the run already
-    // stored says which ones are still open; the client's copy of the message
-    // says what the user decided about each.
-    const resumeRows = message.role === 'assistant' ? loadRunRows(deps.db, runId) : [];
-    const resolutions = resolutionsFor(message, resumeRows);
-    // The engine runs on pi messages; the entries keep each one's row id so a
-    // compaction checkpoint can name the last row it folded away.
-    const entries = loadThreadHistory(deps.db, threadId);
-    startThreadRun(
+    deps.runner.start({
       threadId,
-      (piLog) =>
-        runAgent({
-          runId,
-          providerId,
-          modelId,
-          piModel,
-          streamFn: piStreamFn,
-          getApiKey: makeGetApiKey(deps.db),
-          messages: entries.map((entry) => entry.message),
-          workspaceRoot,
-          threadId,
-          db: deps.db,
-          sandbox,
-          skills,
-          permissionMode: mode,
-          permission: {
-            mode,
-            rules: getSettings('permissions.trustRules'),
-            // Resolve the reviewer only when auto-review can actually use it; a
-            // misconfigured/removed model resolves to undefined, so auto-review
-            // simply falls back to prompting rather than failing the turn.
-            review:
-              mode === 'auto-review'
-                ? resolveReviewer(deps.db, { providerId, modelId })
-                : undefined,
-          },
-          resolutions,
-          resumeRows,
-          abortSignal: abort.signal,
-          emit: piLog.append,
-          persist: (rows, opts) => persistRun(deps.db, threadId, runId, rows, opts),
-          persistCheckpoint: (checkpoint) =>
-            persistCheckpoint(deps.db, threadId, checkpoint, entries[checkpoint.coveredThrough].id),
-          recordUsage: (u) =>
-            recordUsage(deps.db, { threadId, kind: 'chat', ...u }, modelPricing(u.modelId)),
-          generateTitle: getSettings('general.autoGenerateTitle')
-            ? ({ messages, complete }) =>
-                generateThreadTitle({
-                  messages,
-                  complete,
-                  onTitle: (title) => {
-                    setThreadTitle(deps.db, threadId, title);
-                    piLog.append({ type: 'notice', name: 'title', payload: { data: { title } } });
-                  },
-                })
-            : undefined,
-          onSettled: () => computerUse?.hideOverlay(),
-          buildTools: (run) => {
-            const toolCtx = {
-              sandbox,
-              workspaceRoot,
-              run,
-              skills,
-              // A nested loop (the task tool) runs on the same handles as this turn.
-              engine: {
-                model: piModel,
-                streamFn: piStreamFn,
-                getApiKey: makeGetApiKey(deps.db),
-              },
-              bgShells,
-              supportsImageToolResults: supportsImages,
-              computerUse,
-              mcpTools: buildMcpTools(mcpManager.catalog(), mcpManager, {
-                supportsImageToolResults: supportsImages,
-                workspaceRoot,
-              }),
-              permission: {
-                mode,
-                rules: getSettings('permissions.trustRules'),
-                // Resolve the reviewer only when auto-review can actually use it; a
-                // misconfigured/removed model resolves to undefined, so auto-review
-                // simply falls back to prompting rather than failing the turn.
-                review:
-                  mode === 'auto-review'
-                    ? resolveReviewer(deps.db, { providerId, modelId })
-                    : undefined,
-                abortSignal: abort.signal,
-              },
-            };
-            return getTools(toolCtx);
-          },
-        }),
-      abort,
-    );
+      providerId,
+      modelId,
+      permissionMode,
+      userMessage: message.role === 'user' ? message : undefined,
+      resumeRunId,
+      resolutions,
+    });
     return runResponse(threadId);
   });
 
@@ -344,28 +201,14 @@ export function startHttpServer(deps: {
     if (!isThreadRunning(c.req.param('threadId'))) return c.body(null, 204);
     const raw = Number(c.req.query('from') ?? '-1');
     const sse = subscribePiEvents(c.req.param('threadId'), Number.isFinite(raw) ? raw : -1);
-    return sse
-      ? new Response(sse, {
-          headers: {
-            'Content-Type': 'text/event-stream',
-            'Cache-Control': 'no-cache',
-            Connection: 'keep-alive',
-          },
-        })
-      : c.body(null, 204);
+    return sse ? new Response(sse, { headers: PI_SSE_HEADERS }) : c.body(null, 204);
   });
 
   // serve() binds asynchronously; the real port arrives in the listening
   // callback (server.address() is null synchronously right after).
   return new Promise((resolve) => {
     serve({ fetch: app.fetch, hostname: '127.0.0.1', port: 0 }, (info) => {
-      resolve({
-        port: info.port,
-        token: deps.token,
-        dispose: () => {
-          bgShells.killAll();
-        },
-      });
+      resolve({ port: info.port, token: deps.token });
     });
   });
 }

--- a/src/main/server/http.ts
+++ b/src/main/server/http.ts
@@ -1,19 +1,19 @@
 import { serve } from '@hono/node-server';
 import type { AtriumUIMessage } from '@shared/chat';
 import type { PermissionMode } from '@shared/permissions';
+import type { ToolCall, ToolResultMessage } from '@shared/protocol';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import type { Resolution } from '../agent/pi/approvals';
-import { toolCallsById } from '../agent/pi/approvals';
+import { openResolutions, resultFor, toolCallsById } from '../agent/pi/approvals';
 import { foldToCheckpoint } from '../agent/pi/compaction';
-import type { RunRow } from '../agent/pi/recorder';
 import { createSummarizer } from '../agent/pi/summarize';
 import { preserveActiveSkill } from '../agent/tools/builtins/skill';
 import { preserveTodos } from '../agent/tools/builtins/todo';
 import type { Db } from '../db';
 import { createLogger } from '../log';
 import { makeGetApiKey, piStreamFn, resolvePiModel } from '../providers/pi-model';
-import { loadRunRows, loadThreadHistory, persistCheckpoint, resolveToolOutput } from './persist';
+import { loadRunRows, loadThreadHistory, persistCheckpoint, settleRunCalls } from './persist';
 import { subscribePiEvents } from './pi-events';
 import { abortThreadRun, isThreadRunning } from './resumable';
 import type { Runner } from './runner';
@@ -34,50 +34,24 @@ function runResponse(threadId: string): Response {
     : new Response('event log missing', { status: 500 });
 }
 
-// Client sends only the latest message; the server rebuilds history from the DB. The thread row always exists before
-// the chat view can send (the home view creates it, then navigates), so
-// threadId is a hard requirement — its absence is a bug, not a degraded mode.
-type ChatBody = {
+/** What every request that starts a run has to say. */
+type RunBody = {
   threadId: string;
   providerId: string;
   modelId: string;
-  message: AtriumUIMessage;
   permissionMode?: PermissionMode;
 };
 
-const log = createLogger('chat');
+// The client sends only the turn it just wrote; the server rebuilds the history
+// from the DB. The thread row always exists before the chat view can send (the
+// home view creates it, then navigates), so threadId is a hard requirement —
+// its absence is a bug, not a degraded mode.
+type ChatBody = RunBody & { message: AtriumUIMessage };
 
-/**
- * The decisions a resumed message carries for the calls its run left open. The
- * stored rows are the authority on which calls are still waiting; the client's
- * copy of the message carries the user's answer for each.
- */
-function resolutionsFor(message: AtriumUIMessage, resumeRows: RunRow[]): Resolution[] {
-  if (message.role !== 'assistant' || resumeRows.length === 0) return [];
-  const answered = new Set(resumeRows.flatMap((r) => (r.role === 'toolResult' ? [r.id] : [])));
-  const open = toolCallsById(resumeRows.map((r) => r.message));
-  const out: Resolution[] = [];
-  for (const part of message.parts) {
-    const p = part as {
-      toolCallId?: string;
-      state?: string;
-      output?: unknown;
-      approval?: { approved?: boolean; reason?: string };
-    };
-    const toolCallId = p.toolCallId;
-    if (!toolCallId || answered.has(toolCallId) || !open.has(toolCallId)) continue;
-    if (p.state === 'approval-responded') {
-      out.push(
-        p.approval?.approved
-          ? { toolCallId, kind: 'approved' }
-          : { toolCallId, kind: 'denied', reason: p.approval?.reason },
-      );
-    } else if (p.state === 'output-available') {
-      out.push({ toolCallId, kind: 'answered', output: p.output });
-    }
-  }
-  return out;
-}
+/** The user's answers for the calls a run parked, addressed to that run. */
+type DecisionsBody = { runId: string; decisions: Resolution[] };
+
+const log = createLogger('chat');
 
 /**
  * Localhost HTTP server for AI streaming. Lives alongside electron-trpc: tRPC
@@ -114,26 +88,52 @@ export function startHttpServer(deps: {
   app.post('/api/chat', async (c) => {
     const { threadId, providerId, modelId, message, permissionMode } = await c.req.json<ChatBody>();
     if (!threadId) return c.text('threadId required', 400);
+    if (message?.role !== 'user') return c.text('chat takes a user message', 400);
 
-    // An assistant message arrives only when a client-side tool (a clarification
-    // or an approval) was just answered and the chat auto-resumed: the run it
-    // belongs to is continued, and the message is read for the user's decisions
-    // rather than stored.
-    const resumeRunId = message.role === 'assistant' ? message.id : undefined;
-    const resolutions = resumeRunId
-      ? resolutionsFor(message, loadRunRows(deps.db, resumeRunId))
-      : [];
+    deps.runner.start({ threadId, providerId, modelId, permissionMode, userMessage: message });
+    return runResponse(threadId);
+  });
+
+  /**
+   * Continue a run with what the user decided about the calls it parked — an
+   * approval answered, a clarification filled in. The decisions travel as
+   * decisions: the stored rows say which calls are still open, so a client that
+   * is out of date can only ask for less than it thinks, never for more.
+   */
+  app.post('/api/chat/:threadId/resume', async (c) => {
+    const threadId = c.req.param('threadId');
+    const { providerId, modelId, permissionMode, runId, decisions } = await c.req.json<
+      RunBody & DecisionsBody
+    >();
+    const resolutions = openResolutions(loadRunRows(deps.db, runId), decisions ?? []);
+    if (resolutions.length === 0) return c.text('no open call to resume', 409);
 
     deps.runner.start({
       threadId,
       providerId,
       modelId,
       permissionMode,
-      userMessage: message.role === 'user' ? message : undefined,
-      resumeRunId,
+      resumeRunId: runId,
       resolutions,
     });
     return runResponse(threadId);
+  });
+
+  /**
+   * Record decisions without running the model. Used when a decision closes a
+   * call but must not resume the turn — a cancelled clarification, where the
+   * user has taken the turn back and will send again themselves. The call still
+   * has to be closed, or the next request's history carries an unpaired call.
+   */
+  app.post('/api/chat/:threadId/decisions', async (c) => {
+    const { runId, decisions } = await c.req.json<DecisionsBody>();
+    const rows = loadRunRows(deps.db, runId);
+    const calls = toolCallsById(rows.map((r) => r.message));
+    const results = openResolutions(rows, decisions ?? [])
+      .map((d) => resultFor(calls.get(d.toolCallId) as ToolCall, d))
+      .filter((r): r is ToolResultMessage => r !== null);
+    settleRunCalls(deps.db, c.req.param('threadId'), runId, results);
+    return c.json({ settled: results.length });
   });
 
   // Stop a thread's in-flight generation. Aborts the agent loop server-side
@@ -142,14 +142,6 @@ export function startHttpServer(deps: {
   app.post('/api/chat/:threadId/abort', (c) => {
     const aborted = abortThreadRun(c.req.param('threadId'));
     return c.json({ aborted });
-  });
-
-  // Resolve a client-side tool call (a cancelled clarification) in the DB
-  // without running the model — the turn only resumes on the user's next send.
-  app.post('/api/chat/:threadId/resolve-clarify', async (c) => {
-    const { toolCallId, output } = await c.req.json<{ toolCallId: string; output: unknown }>();
-    resolveToolOutput(deps.db, c.req.param('threadId'), toolCallId, output);
-    return c.json({ ok: true });
   });
 
   // Force-compact a thread on demand (user-invoked /compact). Summarizes the

--- a/src/main/server/persist-convert.ts
+++ b/src/main/server/persist-convert.ts
@@ -11,19 +11,24 @@ import type {
 } from '@shared/protocol';
 
 /**
- * Converters between the run-shaped UIMessage the engine and renderer still
- * speak and the pi-native rows the DB stores: one row per pi message — the
- * user message, one assistant message per step, and each tool result its own
- * row — grouped by the run id. Splitting happens on write, merging on read;
- * both directions are mechanical and round-trip exactly over the part
+ * Converters between the run-shaped UIMessage the renderer consumes and the
+ * pi-native rows the DB stores: one row per pi message — the user message, one
+ * assistant message per step, and each tool result its own row — grouped by the
+ * run id. Both directions are mechanical and round-trip exactly over the part
  * inventory real threads contain.
+ *
+ * Merging serves the renderer. Splitting has two remaining callers: the user's
+ * own turn, which arrives in the composer's part shape, and a legacy row (run
+ * id null, still holding a flat part array) being read back as history — which
+ * is why an assistant split stamps `api: 'ai-sdk'`, the engine those rows were
+ * actually produced by. Nothing else writes through this file any more.
  *
  * UI-only tool state pi has no slot for (pending/answered approvals, a call
  * still streaming its input) lives in the row's metadata under `toolStates`,
  * next to the run metadata on the first row — the pi message JSON stays a
  * clean subset-plus-nothing of pi's vocabulary.
  *
- * Known, deliberate losses on the write side (documented, not accidental):
+ * Known, deliberate losses when splitting (documented, not accidental):
  * reasoning providerMetadata is reduced to the anthropic signature
  * (thinkingSignature), and tool-part provider bookkeeping
  * (callProviderMetadata, toolMetadata, providerExecuted) is dropped.

--- a/src/main/server/persist.ts
+++ b/src/main/server/persist.ts
@@ -6,6 +6,7 @@ import { asc, eq, or } from 'drizzle-orm';
 import { withModelAttachments } from '../agent/pi/attachments';
 import type { Checkpoint } from '../agent/pi/compaction';
 import { sealDanglingToolCalls } from '../agent/pi/history';
+import type { RunRow } from '../agent/pi/recorder';
 import type { Db } from '../db';
 import { messages, projects, threads } from '../db/schema';
 import {
@@ -361,18 +362,6 @@ function writePiMessage(db: Db, threadId: string, msg: AtriumUIMessage, overwrit
     });
   });
 }
-
-/**
- * One pi message a run produced, ready to become a row. `id` is the row key:
- * `<runId>:<turn>` for an assistant turn, the tool call id for its results —
- * the same keys the split converters have always written.
- */
-export type RunRow = {
-  id: string;
-  role: 'assistant' | 'toolResult';
-  message: Message;
-  metadata?: Record<string, unknown> | null;
-};
 
 /**
  * Write a run's pi messages as its rows, replacing whatever the run had before.

--- a/src/main/server/persist.ts
+++ b/src/main/server/persist.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { AtriumUIMessage } from '@shared/chat';
-import type { Message } from '@shared/protocol';
+import type { Message, ToolResultMessage } from '@shared/protocol';
 
 import { asc, eq, or } from 'drizzle-orm';
 import { withModelAttachments } from '../agent/pi/attachments';
@@ -270,18 +270,6 @@ export function loadThreadMessageDtos(db: Db, threadId: string): ThreadMessageDt
   return loadThreadMessages(db, threadId) as ThreadMessageDto[];
 }
 
-/** Whether any stored row belongs to this message (either generation). */
-function messageExists(db: Db, id: string): boolean {
-  return (
-    db
-      .select({ id: messages.id })
-      .from(messages)
-      .where(or(eq(messages.runId, id), eq(messages.id, id)))
-      .limit(1)
-      .get() !== undefined
-  );
-}
-
 /** The original wall-clock position of a stored message, for rewrites. */
 function messageBaseCreatedAt(db: Db, id: string): number | undefined {
   return db
@@ -292,75 +280,6 @@ function messageBaseCreatedAt(db: Db, id: string): number | undefined {
     .limit(1)
     .get()
     ?.createdAt?.getTime();
-}
-
-/**
- * Write one run-shaped message as pi-native rows. An assistant run rewrites
- * atomically (delete the run's rows — including a legacy-generation row under
- * the same id — and reinsert), keeping its original chronological position;
- * per-row createdAt offsets preserve in-run order under the createdAt sort.
- */
-function writePiMessage(db: Db, threadId: string, msg: AtriumUIMessage, overwrite: boolean): void {
-  if (msg.role === 'user') {
-    const row = splitUserMessage(msg as AtriumUIMessage);
-    const values = {
-      id: row.id,
-      threadId,
-      role: 'user' as const,
-      parts: row.message,
-      metadata: row.metadata,
-      runId: row.runId,
-    };
-    const insert = db.insert(messages).values(values);
-    if (overwrite) {
-      insert
-        .onConflictDoUpdate({
-          target: messages.id,
-          set: { parts: row.message, metadata: row.metadata, runId: row.runId },
-        })
-        .run();
-    } else {
-      insert.onConflictDoNothing({ target: messages.id }).run();
-    }
-    return;
-  }
-
-  if (msg.role !== 'assistant') {
-    // System rows have no pi vocabulary; store them as legacy rows unchanged.
-    db.insert(messages)
-      .values({
-        id: msg.id,
-        threadId,
-        role: msg.role,
-        parts: msg.parts,
-        metadata: msg.metadata ?? null,
-      })
-      .onConflictDoNothing({ target: messages.id })
-      .run();
-    return;
-  }
-
-  if (!overwrite && messageExists(db, msg.id)) return;
-  const base = messageBaseCreatedAt(db, msg.id) ?? Date.now();
-  const rows = splitAssistantMessage(msg as AtriumUIMessage);
-  db.transaction((tx) => {
-    tx.delete(messages)
-      .where(or(eq(messages.runId, msg.id), eq(messages.id, msg.id)))
-      .run();
-    rows.forEach((row, index) => {
-      tx.insert(messages)
-        .values({
-          id: row.id,
-          threadId,
-          role: row.role,
-          parts: row.message,
-          metadata: row.metadata,
-          runId: row.runId,
-          createdAt: new Date(base + index),
-        })
-        .run();
-    });
-  });
 }
 
 /**
@@ -405,65 +324,55 @@ export function persistRun(
 }
 
 /**
- * Persist one AtriumUIMessage into a thread, storing its parts verbatim (the
- * canonical message shape). Idempotent on message id so re-sends / retries
- * don't duplicate. Bumps the thread's updatedAt so the sidebar re-sorts.
+ * Store the user's turn as its own pi-native row. Idempotent on the message id
+ * so a re-send can't duplicate it, and it bumps the thread's updatedAt so the
+ * sidebar re-sorts. Sending counts as reading, so lastReadAt moves with it —
+ * a thread must never flash "unread" from your own message.
  */
-export function persistMessage(db: Db, threadId: string, msg: AtriumUIMessage): void {
-  writePiMessage(db, threadId, msg, false);
+export function persistUserTurn(db: Db, threadId: string, msg: AtriumUIMessage): void {
+  const row = splitUserMessage(msg);
+  db.insert(messages)
+    .values({
+      id: row.id,
+      threadId,
+      role: 'user',
+      parts: row.message,
+      metadata: row.metadata,
+      runId: row.runId,
+    })
+    .onConflictDoNothing({ target: messages.id })
+    .run();
   const now = new Date();
-  // Sending counts as reading: stamp lastReadAt = updatedAt for the user's own
-  // message so a thread never flashes "unread" from your own send (only a later
-  // assistant turn bumps updatedAt past lastReadAt).
-  const bump = msg.role === 'user' ? { updatedAt: now, lastReadAt: now } : { updatedAt: now };
-  db.update(threads).set(bump).where(eq(threads.id, threadId)).run();
+  db.update(threads).set({ updatedAt: now, lastReadAt: now }).where(eq(threads.id, threadId)).run();
 }
 
 /**
- * Insert a message or overwrite an existing one's parts/metadata in place. Two
- * cases need the overwrite, both keyed on a reused message id: the client
- * re-sends an assistant message whose client-side tool (ask_clarification) just
- * got its answer, and the model continues that same assistant message after the
- * answer (the continuation extends it under the same id rather than minting a
- * new one). Insert-and-ignore would silently drop it.
+ * Close a run's parked calls with the results the user's decisions produced,
+ * without running the model. Used when a decision settles a call but must not
+ * resume the turn — a cancelled clarification, where the user has taken the
+ * turn back and will send again themselves.
+ *
+ * The results are appended to the run and the whole run is rewritten, which is
+ * how every other write to a run works: the group stays contiguous and keeps
+ * its position in the thread.
  */
-export function upsertMessage(
+export function settleRunCalls(
   db: Db,
   threadId: string,
-  msg: AtriumUIMessage,
-  opts?: { markRead?: boolean },
+  runId: string,
+  results: ToolResultMessage[],
 ): void {
-  writePiMessage(db, threadId, msg, true);
-  const now = new Date();
-  // markRead stamps lastReadAt = updatedAt so this write can't trip the sidebar's
-  // unread dot — used when the user stops a turn, since the partial message is
-  // persisted on a thread they're actively viewing.
-  const bump = opts?.markRead ? { updatedAt: now, lastReadAt: now } : { updatedAt: now };
-  db.update(threads).set(bump).where(eq(threads.id, threadId)).run();
-}
-
-/**
- * Fill a client-side tool call's result into the stored message without running
- * the model — used when a clarification is cancelled: the call must be resolved
- * (so the next turn's history isn't a dangling tool_use) but no continuation
- * should fire until the user sends again.
- */
-export function resolveToolOutput(
-  db: Db,
-  threadId: string,
-  toolCallId: string,
-  output: unknown,
-): void {
-  const msg = loadThreadMessages(db, threadId).find((m) =>
-    m.parts.some((p) => (p as { toolCallId?: string }).toolCallId === toolCallId),
-  );
-  if (!msg) return;
-  const parts = msg.parts.map((p) =>
-    (p as { toolCallId?: string }).toolCallId === toolCallId
-      ? { ...p, state: 'output-available', output }
-      : p,
-  ) as AtriumUIMessage['parts'];
-  upsertMessage(db, threadId, { ...msg, parts });
+  if (results.length === 0) return;
+  const rows = loadRunRows(db, runId);
+  if (rows.length === 0) return;
+  persistRun(db, threadId, runId, [
+    ...rows,
+    ...results.map((message) => ({
+      id: message.toolCallId,
+      role: 'toolResult' as const,
+      message,
+    })),
+  ]);
 }
 
 /** Replace a thread's title with the model-generated summary of its first message. */

--- a/src/main/server/resumable.ts
+++ b/src/main/server/resumable.ts
@@ -32,16 +32,20 @@ export function abortThreadRun(threadId: string): boolean {
   return true;
 }
 
-/** Start a thread's run; a newer run on the same thread supersedes this one's
- *  registry slot without cancelling it. */
+/**
+ * Start a thread's run; a newer run on the same thread supersedes this one's
+ * registry slot without cancelling it. The thread's event log exists by the time
+ * this returns, so a caller can subscribe to it immediately. The returned
+ * promise settles when the run has finished and its log is sealed.
+ */
 export function startThreadRun(
   threadId: string,
   produce: (log: RunLog) => Promise<void>,
   abort: AbortController,
-): void {
+): Promise<void> {
   const token: Run = { abort };
   runByThread.set(threadId, token);
-  void withRunLog(threadId, produce).finally(() => {
+  return withRunLog(threadId, produce).finally(() => {
     if (runByThread.get(threadId) === token) runByThread.delete(threadId);
   });
 }

--- a/src/main/server/runner.ts
+++ b/src/main/server/runner.ts
@@ -22,8 +22,8 @@ import {
   loadRunRows,
   loadThreadHistory,
   persistCheckpoint,
-  persistMessage,
   persistRun,
+  persistUserTurn,
   resolveThreadWorkspace,
   setThreadTitle,
 } from './persist';
@@ -111,7 +111,7 @@ export function createRunner(deps: { db: Db; projectlessRoot: string }): Runner 
       const { threadId, providerId, modelId } = request;
       // The turn's history is rebuilt from the DB below, which is the source of
       // truth — the caller only supplies the message that starts it.
-      if (request.userMessage) persistMessage(db, threadId, request.userMessage);
+      if (request.userMessage) persistUserTurn(db, threadId, request.userMessage);
 
       // The thread's workspace: its project's directory, or the projectless
       // fallback. Drives the sandbox and the tools below.

--- a/src/main/server/runner.ts
+++ b/src/main/server/runner.ts
@@ -1,0 +1,218 @@
+import { randomUUID } from 'node:crypto';
+import type { AtriumUIMessage } from '@shared/chat';
+import { DEFAULT_PERMISSION_MODE, type PermissionMode } from '@shared/permissions';
+import { mcpManager } from '../agent/mcp/manager';
+import { buildMcpTools } from '../agent/mcp/tool-adapter';
+import { modelPricing } from '../agent/models/catalog';
+import type { Resolution } from '../agent/pi/approvals';
+import { type Complete, createCompleter } from '../agent/pi/complete';
+import { generateThreadTitle } from '../agent/pi/title';
+import { runAgent } from '../agent/run';
+import { BackgroundShells, LocalSandbox } from '../agent/sandbox';
+import { getSkills } from '../agent/skills/registry';
+import { getTools } from '../agent/tools';
+import { getComputerUseHelper } from '../computer-use';
+import type { Db } from '../db';
+import { recordUsage } from '../db/usage';
+import { createLogger } from '../log';
+import { makeGetApiKey, piStreamFn, resolvePiModel } from '../providers/pi-model';
+import { supportsImageToolResults } from '../providers/resolve';
+import { getSettings } from '../settings/conf';
+import {
+  loadRunRows,
+  loadThreadHistory,
+  persistCheckpoint,
+  persistMessage,
+  persistRun,
+  resolveThreadWorkspace,
+  setThreadTitle,
+} from './persist';
+import { startThreadRun } from './resumable';
+
+const log = createLogger('runner');
+
+/** One turn to run on a thread. */
+export type RunRequest = {
+  threadId: string;
+  providerId: string;
+  modelId: string;
+  permissionMode?: PermissionMode;
+  /** A new user turn to append before the run starts. */
+  userMessage?: AtriumUIMessage;
+  /** Extend the run with this id — answering the calls it parked — instead of
+   *  opening a new one. */
+  resumeRunId?: string;
+  /** What the user decided about the calls the resumed run parked. */
+  resolutions?: Resolution[];
+};
+
+/** How a turn ended, for a caller that isn't reading the event stream. */
+export type RunOutcome = {
+  runId: string;
+  status: 'ok' | 'error';
+  error?: string;
+  /** The stored assistant message, when the run produced one. */
+  messageId?: string;
+};
+
+export type RunHandle = { runId: string; settled: Promise<RunOutcome> };
+
+/**
+ * The composition root for a turn: everything a run needs — workspace, sandbox,
+ * model, tools, permissions, persistence — is assembled here and nowhere else.
+ *
+ * It exists so that starting a turn is a function call rather than an HTTP
+ * request. The chat endpoint and the scheduler are both callers; neither can
+ * see how a run is put together, and neither has to reach the other through the
+ * loopback interface to start one.
+ */
+export type Runner = {
+  /**
+   * Start a turn. Returns once the thread's event log exists — a caller can
+   * subscribe to the stream immediately — with a promise for the outcome.
+   * Throws synchronously when the request can't run at all (an unknown model).
+   */
+  start(request: RunRequest): RunHandle;
+  dispose(): void;
+};
+
+/**
+ * Resolve the auto-review reviewer model. Prefers the dedicated setting; when
+ * unset, falls back to this turn's chat model so auto-review works out of the
+ * box. Returns undefined (→ auto-review prompts) when nothing resolves — a
+ * removed model.
+ */
+function resolveReviewer(
+  db: Db,
+  fallback: { providerId: string; modelId: string },
+): Complete | undefined {
+  const configured = getSettings('permissions.reviewerModel');
+  const picked = configured ?? fallback;
+  try {
+    const model = resolvePiModel(db, picked.providerId, picked.modelId);
+    log.info(
+      `reviewer = ${picked.providerId}/${picked.modelId}${configured ? '' : ' (inherited chat model)'}`,
+    );
+    return createCompleter({ model, streamFn: piStreamFn, getApiKey: makeGetApiKey(db) });
+  } catch (err) {
+    log.info(`reviewer unresolved (${picked.providerId}/${picked.modelId}) → prompts: ${err}`);
+    return undefined;
+  }
+}
+
+export function createRunner(deps: { db: Db; projectlessRoot: string }): Runner {
+  const { db } = deps;
+  // Long-running shells (dev servers, watchers) outlive a turn, so the registry
+  // is one instance held for the runner's lifetime, not per-run.
+  const bgShells = new BackgroundShells();
+
+  return {
+    start(request: RunRequest): RunHandle {
+      const { threadId, providerId, modelId } = request;
+      // The turn's history is rebuilt from the DB below, which is the source of
+      // truth — the caller only supplies the message that starts it.
+      if (request.userMessage) persistMessage(db, threadId, request.userMessage);
+
+      // The thread's workspace: its project's directory, or the projectless
+      // fallback. Drives the sandbox and the tools below.
+      const workspaceRoot = resolveThreadWorkspace(db, threadId, deps.projectlessRoot);
+      const abort = new AbortController();
+      const sandbox = new LocalSandbox(workspaceRoot);
+      const skills = getSkills();
+      const mode = request.permissionMode ?? DEFAULT_PERMISSION_MODE;
+      const supportsImages = supportsImageToolResults(providerId, modelId);
+      const computerUse =
+        process.platform === 'darwin' && getSettings('computerUse.enabled')
+          ? getComputerUseHelper()
+          : undefined;
+      const piModel = resolvePiModel(db, providerId, modelId);
+      // A continuation extends the run it answers, so the model's next turns
+      // land in that same stored run instead of opening a second one.
+      const runId = request.resumeRunId ?? randomUUID();
+      const resumeRows = request.resumeRunId ? loadRunRows(db, request.resumeRunId) : [];
+      // The engine runs on pi messages; the entries keep each one's row id so a
+      // compaction checkpoint can name the last row it folded away.
+      const entries = loadThreadHistory(db, threadId);
+      // Resolve the reviewer only when auto-review can actually use it; a
+      // misconfigured/removed model resolves to undefined, so auto-review simply
+      // falls back to prompting rather than failing the turn.
+      const review =
+        mode === 'auto-review' ? resolveReviewer(db, { providerId, modelId }) : undefined;
+
+      let result: Awaited<ReturnType<typeof runAgent>> | undefined;
+      const finished = startThreadRun(
+        threadId,
+        async (piLog) => {
+          result = await runAgent({
+            runId,
+            providerId,
+            modelId,
+            piModel,
+            streamFn: piStreamFn,
+            getApiKey: makeGetApiKey(db),
+            messages: entries.map((entry) => entry.message),
+            workspaceRoot,
+            threadId,
+            db,
+            sandbox,
+            skills,
+            permissionMode: mode,
+            permission: { mode, rules: getSettings('permissions.trustRules'), review },
+            resolutions: request.resolutions,
+            resumeRows,
+            abortSignal: abort.signal,
+            emit: piLog.append,
+            persist: (rows, opts) => persistRun(db, threadId, runId, rows, opts),
+            persistCheckpoint: (checkpoint) =>
+              persistCheckpoint(db, threadId, checkpoint, entries[checkpoint.coveredThrough].id),
+            recordUsage: (u) =>
+              recordUsage(db, { threadId, kind: 'chat', ...u }, modelPricing(u.modelId)),
+            generateTitle: getSettings('general.autoGenerateTitle')
+              ? ({ messages, complete }) =>
+                  generateThreadTitle({
+                    messages,
+                    complete,
+                    onTitle: (title) => {
+                      setThreadTitle(db, threadId, title);
+                      piLog.append({ type: 'notice', name: 'title', payload: { data: { title } } });
+                    },
+                  })
+              : undefined,
+            onSettled: () => computerUse?.hideOverlay(),
+            buildTools: (run) =>
+              getTools({
+                sandbox,
+                workspaceRoot,
+                run,
+                skills,
+                // A nested loop (the task tool) runs on the same handles as this turn.
+                engine: { model: piModel, streamFn: piStreamFn, getApiKey: makeGetApiKey(db) },
+                bgShells,
+                supportsImageToolResults: supportsImages,
+                computerUse,
+                mcpTools: buildMcpTools(mcpManager.catalog(), mcpManager, {
+                  supportsImageToolResults: supportsImages,
+                  workspaceRoot,
+                }),
+              }),
+          });
+        },
+        abort,
+      );
+
+      return {
+        runId,
+        settled: finished.then(() => ({
+          runId,
+          status: result?.status ?? 'error',
+          error: result?.error ?? (result ? undefined : 'the run ended without reporting'),
+          messageId: result?.stored ? runId : undefined,
+        })),
+      };
+    },
+
+    dispose() {
+      bgShells.killAll();
+    },
+  };
+}

--- a/src/renderer/src/lib/pi-chat/store.ts
+++ b/src/renderer/src/lib/pi-chat/store.ts
@@ -1,7 +1,7 @@
 import type { AtriumUIMessage } from '@shared/chat';
 import type { ClarifyResult } from '@shared/chat-types';
 import type { PermissionMode } from '@shared/permissions';
-import type { EventEnvelope } from '@shared/protocol';
+import type { EventEnvelope, ToolDecision } from '@shared/protocol';
 import {
   type ChatStatus,
   generateId,
@@ -17,10 +17,10 @@ import { RunAssembler } from './reduce';
  * SSE; reconnects replay the envelope log from seq 0. Messages are assembled
  * by RunAssembler in the part shape the components already consume.
  *
- * Continuations (a clarify answered, an approval decided) re-send the
- * assistant message and seed the assembler with its parts — the new run's
- * events extend that message in place, mirroring how the server upserts the
- * same row. Auto-resume replicates useChat's sendAutomaticallyWhen contract.
+ * Continuations (a clarify answered, an approval decided) post the user's
+ * decisions to the run that parked those calls and seed the assembler with the
+ * message's parts, so the new run's events extend that message in place.
+ * Auto-resume replicates useChat's sendAutomaticallyWhen contract.
  */
 
 export type PiChatSnapshot = {
@@ -81,6 +81,24 @@ function toolRoundComplete(messages: AtriumUIMessage[]): boolean {
   return tools.length > 0 && tools.every((p) => p.state === 'output-available');
 }
 
+/** The user's answers for the last step's parked calls, as the wire states them. */
+function decisionsOf(messages: AtriumUIMessage[]): ToolDecision[] {
+  const out: ToolDecision[] = [];
+  for (const part of lastStepToolParts(messages)) {
+    const toolCallId = part.toolCallId;
+    if (part.state === 'approval-responded') {
+      out.push(
+        part.approval?.approved
+          ? { toolCallId, kind: 'approved' }
+          : { toolCallId, kind: 'denied', reason: part.approval?.reason },
+      );
+    } else if (part.state === 'output-available') {
+      out.push({ toolCallId, kind: 'answered', output: part.output });
+    }
+  }
+  return out;
+}
+
 /** Every pending approval got its answer — the turn can continue and execute. */
 function approvalsAnswered(messages: AtriumUIMessage[]): boolean {
   const tools = lastStepToolParts(messages);
@@ -137,7 +155,7 @@ export class PiChat {
       metadata: { createdAt: Date.now() },
     };
     this.history = [...this.history, message];
-    void this.post(message);
+    void this.post({ path: '/api/chat', body: { message } });
   };
 
   /** Reconnect to a still-running stream; a 204 means nothing to rejoin. */
@@ -195,33 +213,40 @@ export class PiChat {
   };
 
   /** useChat's sendAutomaticallyWhen contract: a completed tool round or an
-   *  answered approval resumes the turn by re-sending the assistant message. */
+   *  answered approval resumes the turn the decisions belong to. */
   private maybeAutoResume(): void {
     if (this.isBusy) return;
     const messages = this.merged();
     const last = messages.at(-1);
     if (!last || last.role !== 'assistant') return;
     const complete = toolRoundComplete(messages) || approvalsAnswered(messages);
-    if (complete && !lastClarifyCancelled(messages)) void this.post(last);
+    if (!complete || lastClarifyCancelled(messages)) return;
+    void this.post({
+      path: `/api/chat/${this.threadId}/resume`,
+      body: { runId: last.id, decisions: decisionsOf(messages) },
+      // A continuation extends the assistant message in place: seed the
+      // assembler with its parts so the streamed tail lands after them.
+      seed: { id: last.id, parts: last.parts },
+    });
   }
 
-  private async post(message: AtriumUIMessage): Promise<void> {
+  private async post(input: {
+    path: string;
+    body: Record<string, unknown>;
+    seed?: { id: string; parts: Part[] };
+  }): Promise<void> {
     const abort = this.begin('submitted');
-    // A continuation extends the assistant message in place: seed the assembler
-    // with its parts so the streamed tail lands after them.
-    const seed =
-      message.role === 'assistant' ? { id: message.id, parts: message.parts } : undefined;
     try {
-      const res = await this.fetchFn(`${this.init.baseUrl}/api/chat`, {
+      const res = await this.fetchFn(`${this.init.baseUrl}${input.path}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'x-atrium-token': this.init.token },
-        body: JSON.stringify({ ...this.init.getExtras(), message }),
+        body: JSON.stringify({ ...this.init.getExtras(), ...input.body }),
         signal: abort.signal,
       });
       if (!res.ok || !res.body) {
         throw new Error(`chat request failed (${res.status}) ${await res.text().catch(() => '')}`);
       }
-      await this.consume(res.body, seed);
+      await this.consume(res.body, input.seed);
       this.finalizeRun();
     } catch (err) {
       if (!abort.signal.aborted) this.failWith(err);

--- a/src/renderer/src/lib/pi-chat/tests/store.test.ts
+++ b/src/renderer/src/lib/pi-chat/tests/store.test.ts
@@ -149,7 +149,7 @@ describe('continuations', () => {
     metadata: { createdAt: 1 },
   });
 
-  test('an answered clarification auto-resumes with the assistant message', async () => {
+  test('an answered clarification resumes its run with the answer as a decision', async () => {
     const { chat, calls } = makeChat(
       () => new Response(sseBody(sayText('a1', '收到'))),
       [clarifyMessage()],
@@ -157,9 +157,12 @@ describe('continuations', () => {
     chat.addToolOutput({ tool: 'ask_clarification', toolCallId: 'c1', output: { answers: ['A'] } });
     await untilIdle(chat);
     expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('http://test/api/chat/t1/resume');
     const body = JSON.parse(String(calls[0].init?.body));
-    expect(body.message.role).toBe('assistant');
-    expect(body.message.id).toBe('a1');
+    expect(body.runId).toBe('a1');
+    expect(body.decisions).toEqual([
+      { toolCallId: 'c1', kind: 'answered', output: { answers: ['A'] } },
+    ]);
     // The continuation extends the same message: clarify part kept, reply appended.
     const snap = chat.getSnapshot();
     expect(snap.messages).toHaveLength(1);
@@ -216,11 +219,10 @@ describe('continuations', () => {
     chat.addToolApprovalResponse({ id: 'ap1', approved: true });
     await untilIdle(chat);
     expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('http://test/api/chat/t1/resume');
     const body = JSON.parse(String(calls[0].init?.body));
-    expect(body.message.parts.at(-1)).toMatchObject({
-      state: 'approval-responded',
-      approval: { id: 'ap1', approved: true },
-    });
+    expect(body.runId).toBe('a1');
+    expect(body.decisions).toEqual([{ toolCallId: 'b1', kind: 'approved' }]);
     // The seeded part got its execution result under the original toolCallId.
     const bash = chat
       .getSnapshot()

--- a/src/renderer/src/routes/_app/chat/$threadId.tsx
+++ b/src/renderer/src/routes/_app/chat/$threadId.tsx
@@ -131,20 +131,28 @@ function ChatRunner({
     }).catch(() => {});
   }, [stop, setMessages, endpoint.baseUrl, endpoint.token, threadId]);
 
-  // Cancelling a clarification: resolve the call so the next turn's history is
+  // Cancelling a clarification: close the call so the next turn's history is
   // valid, but don't auto-resume (the store's sendAutomaticallyWhen skips a
-  // cancelled clarify). Persist it server-side without running the model.
+  // cancelled clarify). The decision is recorded server-side without running
+  // the model, against the run that parked the call.
   const onCancelClarify = useCallback(
     (toolCallId: string): void => {
       const output: ClarifyResult = { answers: [], cancelled: true };
       addToolOutput({ tool: 'ask_clarification', toolCallId, output });
-      void fetch(`${endpoint.baseUrl}/api/chat/${threadId}/resolve-clarify`, {
+      const runId = messages.find((m) =>
+        m.parts.some((p) => (p as { toolCallId?: string }).toolCallId === toolCallId),
+      )?.id;
+      if (!runId) return;
+      void fetch(`${endpoint.baseUrl}/api/chat/${threadId}/decisions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'x-atrium-token': endpoint.token },
-        body: JSON.stringify({ toolCallId, output }),
+        body: JSON.stringify({
+          runId,
+          decisions: [{ toolCallId, kind: 'answered', output }],
+        }),
       }).catch(() => {});
     },
-    [addToolOutput, endpoint.baseUrl, endpoint.token, threadId],
+    [addToolOutput, messages, endpoint.baseUrl, endpoint.token, threadId],
   );
 
   const utils = trpc.useUtils();

--- a/src/shared/protocol/events.ts
+++ b/src/shared/protocol/events.ts
@@ -83,6 +83,19 @@ export type AgentSessionEvent =
   | { type: 'notice'; name: string; payload: unknown };
 
 /**
+ * What the user came back with for a call the agent parked — the client's half
+ * of the approval protocol, addressed to one call by id.
+ *
+ * A decision is a claim, not an instruction: the server checks it against the
+ * run's stored rows, so a client working from a stale view can only ask for
+ * less than it thinks, never for more.
+ */
+export type ToolDecision =
+  | { toolCallId: string; kind: 'approved' }
+  | { toolCallId: string; kind: 'denied'; reason?: string }
+  | { toolCallId: string; kind: 'answered'; output: unknown };
+
+/**
  * seq is monotonic per stream; reconnecting clients pass their last seen seq
  * and the server replays the gap, making the replay/live seam idempotent.
  */


### PR DESCRIPTION
服务端重构的前三刀，来自这轮 `main/*` 架构分析。每一刀一个 commit，逐刀真机验证过。

## 1. 进程内 run 入口 (`5ca1ffd`)

一轮的装配——workspace / sandbox / model / tools / permissions / persistence——原来长在 chat 端点的 POST handler 里，所以启动一个 run 的唯一方式是发 HTTP 请求。定时任务只能回环访问自己的进程，再用正则扫 SSE 字节判断成败。

装配移到一个 runner，应用启动时建一次，两个调用方共用。起一轮现在是函数调用，返回 run id 和一个结果 promise；HTTP 层只做翻译。

顺带修掉正则永远看不见的东西：provider 失败是一条 stopReason 为 error 的 assistant 消息，不是异常。现在模型层失败的定时任务会真的算失败，喂给连续失败自动暂停。产出的 assistant 消息就是 run id，不用再前后 diff 线程来猜。

也删掉了 `ToolCtx.permission`——全仓库无人读，而为了填它，auto-review 模式每轮多解析一次 reviewer 模型。

## 2. 拆 runAgent (`36f3a7d`)

`runAgent` 一个函数干六件事，`runSubagent` 是它建循环那半边的复制。按本来就存在的接缝拆开：

- **runtime** 建一个 Atrium agent loop（上下文管线、重复刹车、轮次上限、停止转发）——这正是两个调用方真正共享的东西，于是子智能体现在与主轮的差别只剩「往模型面前放什么」；
- **emitter** 决定读者看到什么；
- **recorder** 累积要落库的东西，并持有原来 agent 层和持久化层各声明一份的行类型。

重复刹车挪进 runtime，因为它跨两个必须互相配合的 hook——这正是调用方每次都得重造的耦合。

两处 `convertToLlm` 一并删掉：它们传的恒等函数就是引擎的默认行为。

RunContext 的瞬时通道变成 `notice(name, data)`。它原来是个按 `data-` 前缀路由的开放 stream chunk——已退役引擎的 data part 形状——而且此后没有任何工具用过它。

## 3. 决定走自己的通道 (`1b3b1d4`)

回答审批或澄清，原来是把整条 assistant 消息重新发给 chat 端点，服务端再拿它跟存储行做 diff 反推用户决定了什么。这让一个 UI 消息形状变成了服务端的命令面；写路径也跟着走：填一个 tool 结果要把线程读成 UI 消息、改一个 part、再把整个 run 拆回行。

现在决定就以决定的形式传输。`/resume` 点名 run 并带上它搁置的调用的答案；不该重启轮次的决定（取消澄清）由 `/decisions` 单独记录。两者都对着 run 的存储行核验，所以视图过期的客户端只可能要得比它以为的少，绝不会更多。

写路径彻底脱离 UI 词汇：一个决定就写成它本来就是的 tool 结果行。拆分存储的 assistant 消息现在只剩它一直宣称的用途——读回格式翻转之前的旧行。

**顺带修掉一个 main 上就有的 bug**：读线程时会给上一轮搁置的调用封口，于是用户的答案和那条占位结果一起送出去，provider 因为「一个 tool call 有两个结果」直接拒绝整轮——澄清和审批的续跑一律 400。现在结算的决定会顶掉那条占位。

## 验证

`bun run check` 全绿，577 测试通过（新增 4 条）。真机（CDP 驱动开发版）逐条跑过：

| 路径 | 结果 |
|---|---|
| 普通对话轮 | 模型答出随机口令，行按 run 分组落库、metadata 正确 |
| 子智能体（task → bash） | 子轮跑通，活动通知从 `0 个工具` → `2 个工具` 并列出两条调用 |
| 澄清 → 回答 → 续跑 | 模型复述出答案；修复前这里是 400 |
| 越界调用 → 允许一次 | 工具执行、续跑答对，DB 里该调用恰好一条结果行，且续跑并入同一个 run（`:0` / `:1`） |
| 澄清 → 取消 | 卡片显示已取消、不起新 run、结果行落库 |
| 定时任务 | 不再经 HTTP，改为直接调 runner |

测试线程已全部归档；测试期间改动的权限模式已改回。

## 不在这三刀里

Session（问题 4/5：只在轮次结束时一次性落库、事件日志仅在内存、「一个 thread 一个 run」靠调用方自觉）留到下一步统一看。顺带确认：**pi 没有提供 SQLite 版 session**——`dist/` 里搜不到任何 sqlite，只有 `JsonlSessionRepo`（JSONL 文件）和一个 `./session/testing` 的内存实现；要用 SQLite 得自己实现 `SessionStorage`（约 18 个方法）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsFA5TauSr9tLaizTUqSPp
