### PR TITLE
fix(agent): keep counting tokens once a thread has been compacted

### DIFF
--- a/src/main/agent/runtime/compaction.test.ts
+++ b/src/main/agent/runtime/compaction.test.ts
@@ -1,9 +1,10 @@
 import { expect, test } from 'bun:test';
-import type { AgentMessage } from '@earendil-works/pi-agent-core';
+import { type AgentMessage, createCompactionSummaryMessage } from '@earendil-works/pi-agent-core';
 import type { AssistantMessage, Message, Usage } from '@shared/protocol';
 import {
   compactForTurn,
   type Fold,
+  foldHistory,
   pickRecentTail,
   pickRecentWindow,
   renderTranscript,
@@ -277,4 +278,22 @@ test('a failed within-turn summary runs the request on the view it had', async (
   });
   const messages = [user('go'), call('c1'), result('c1', 'a'), call('c2'), result('c2', 'b')];
   expect(asStored(await fold(asPi(messages)))).toEqual(messages);
+});
+
+test('re-folds a transcript that already carries a compaction summary', async () => {
+  // Compacting twice is ordinary: the standing summary is part of the history
+  // the second fold reads, and it holds its text outside `content`.
+  const summary = createCompactionSummaryMessage('earlier fold', 9, 0) as unknown as Message;
+  const history = [summary, ...Array.from({ length: 8 }, (_, i) => user(`turn ${i}`.repeat(200)))];
+
+  const folded = await foldHistory({
+    messages: history,
+    summarize: async () => 'second summary',
+    contextWindow: 1000,
+    keepRecentTokens: 0,
+  });
+
+  expect(folded).not.toBeNull();
+  expect(folded?.summary).toBe('second summary');
+  expect(folded?.tokensBefore).toBeGreaterThan(0);
 });

--- a/src/main/agent/runtime/tokens.test.ts
+++ b/src/main/agent/runtime/tokens.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'bun:test';
+import { createCompactionSummaryMessage } from '@earendil-works/pi-agent-core';
 import type { AssistantMessage, Message, Usage } from '@shared/protocol';
 import { countTokens, estimateContextTokens, estimateTokens, tokensOfMessage } from './tokens';
 
@@ -102,4 +103,21 @@ test('a cache-served turn is counted at its full prompt size', () => {
 test('a turn with no reported total falls back to summing the parts', () => {
   const cached = assistant('x', usage({ input: 100, output: 5, cacheRead: 900, cacheWrite: 50 }));
   expect(countTokens([user('a'), cached])).toBe(1055);
+});
+
+test("counts pi's own message roles instead of choking on them", () => {
+  // A compacted thread carries a compactionSummary, which holds its text in
+  // `summary` and has no `content` at all.
+  const summary = createCompactionSummaryMessage('folded away', 4321, 0) as unknown as Message;
+
+  expect(() => estimateContextTokens([summary, user('aaaa')])).not.toThrow();
+  // The summary is really in the prompt, so it has to be counted, not skipped.
+  expect(estimateContextTokens([summary])).toBeGreaterThan(estimateTokens('folded away'));
+  expect(estimateContextTokens([summary, user('aaaa')])).toBe(estimateContextTokens([summary]) + 1);
+});
+
+test('still anchors on reported usage across a compaction summary', () => {
+  const summary = createCompactionSummaryMessage('folded away', 4321, 0) as unknown as Message;
+  const messages = [summary, assistant('a', usage({ totalTokens: 1000 })), user('aaaa')];
+  expect(countTokens(messages)).toBe(1001);
 });

--- a/src/main/agent/runtime/tokens.ts
+++ b/src/main/agent/runtime/tokens.ts
@@ -1,3 +1,4 @@
+import { convertToLlm } from '@earendil-works/pi-agent-core';
 import type {
   AssistantMessage,
   Content,
@@ -5,6 +6,7 @@ import type {
   Message,
   TextContent,
 } from '@shared/protocol';
+import { asPi, asStored } from './vocabulary';
 
 /**
  * Token accounting for compaction's threshold check. Not exact — exactness
@@ -63,7 +65,19 @@ function sizeOfContent(content: readonly (Content | TextContent | ImageContent)[
   return { text, images };
 }
 
-/** Size estimate for one message: text-bearing content by length, images flat. */
+/**
+ * The transcript in the three roles this file knows how to size.
+ *
+ * A compacted thread carries pi's own message roles, and those keep their text
+ * somewhere other than `content` — a compaction summary has no `content` field
+ * at all. Converting first turns each into the user turn it stands for, so the
+ * summary is counted at its real weight instead of throwing. Same reason
+ * `renderTranscript` converts before flattening.
+ */
+const sizable = (messages: Message[]): Message[] => asStored(convertToLlm(asPi(messages)));
+
+/** Size estimate for one message: text-bearing content by length, images flat.
+ *  Takes a converted message — see `sizable`. */
 export function tokensOfMessage(message: Message): number {
   if (message.role === 'user' && typeof message.content === 'string') {
     return estimateTokens(message.content);
@@ -98,10 +112,11 @@ function reportedContextTokens(message: Message): number | undefined {
  * becomes the anchor for the next check.
  */
 export function countTokens(messages: Message[]): number {
+  const sized = sizable(messages);
   let anchor = -1;
   let base = 0;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const reported = reportedContextTokens(messages[i]);
+  for (let i = sized.length - 1; i >= 0; i--) {
+    const reported = reportedContextTokens(sized[i]);
     if (reported !== undefined) {
       anchor = i;
       base = reported;
@@ -109,13 +124,13 @@ export function countTokens(messages: Message[]): number {
     }
   }
   let tail = 0;
-  for (let i = anchor + 1; i < messages.length; i++) tail += tokensOfMessage(messages[i]);
+  for (let i = anchor + 1; i < sized.length; i++) tail += tokensOfMessage(sized[i]);
   return base + tail;
 }
 
 /** Pure estimate, for a view whose reported counts no longer describe it. */
 export function estimateContextTokens(messages: Message[]): number {
   let total = 0;
-  for (const message of messages) total += tokensOfMessage(message);
+  for (const message of sizable(messages)) total += tokensOfMessage(message);
   return total;
 }


### PR DESCRIPTION
Stacked on #106 — it touches `agent/runtime/tokens.ts`, which that PR moves. GitHub retargets this to `main` once #106 merges.

## The bug

pi's `CompactionSummaryMessage` is `{ role, summary, tokensBefore, timestamp }` — it holds its text in `summary` and has **no `content` field**. `sizeOfContent` iterated `message.content` directly, so it threw on every transcript that had been compacted.

Two different symptoms, because the two callers have different error handling:

- **Automatic compaction silently died.** The within-turn fold runs as a context transform, and `composeContext` skips a failing transform rather than killing the turn ("a missing injection is survivable, a dead turn is not"). So from a thread's *first* compaction onward, the fold was skipped on every subsequent turn — that thread would never auto-compact again and could run to the context limit. The only trace was one `warn` line per turn:
  ```
  (context) context transform skipped: TypeError: content is not iterable
  ```
- **Forced `/compact` failed outright** on an already-compacted thread. `foldHistory` has no such guard, so the throw propagated.

Shipped in 0.15.0; came in with the session migration (#105), which is when `compactionSummary` started appearing in the transcript. Found in `main.log` while smoke-testing #106, not caused by it.

## The fix

Count through pi's `convertToLlm` first, which is exactly what `renderTranscript` already does and for the same reason. The summary becomes the user turn it stands for, so it is measured at the weight it really carries in the prompt rather than being stepped over. This also covers `branchSummary` and `bashExecution`, which have no `content` either.

## Tests

Two regression tests, both verified to fail without the fix:

- `tokens.test.ts` — sizing a transcript that carries a compaction summary, and that anchoring on reported usage still works across one.
- `compaction.test.ts` — re-folding a transcript that already carries a compaction summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsFA5TauSr9tLaizTUqSPp